### PR TITLE
Multiplatform build with artifacts publishing to bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ executors:
     working_directory: ~/project
     environment:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+      HOMEBREW_NO_AUTO_UPDATE: true
 # besu_executor_med_windows: # 2cpu, 4G ram
 #   machine:
 #     image: "windows-server-2019-vs2019:stable"
@@ -56,13 +57,18 @@ commands:
   prepare_final_assembly:
     description: "Prepare - Final Assembly"
     steps:
-      - attach_workspace:
-          at: secp256k1/build
       - run:
           name: Install Packages - build tools
           command: |
             sudo apt-get update
             sudo apt-get install -y autoconf build-essential libtool
+      - attach_workspace:
+          at: ~/project/secp256k1/build/lib
+      - run:
+          name: "Check workspace"
+          command: |
+            ls ~/project/secp256k1/build
+            ls ~/project/secp256k1/build/lib
 jobs:
   native-build-linux-x86-64:
     executor: besu_executor_med_linux
@@ -76,9 +82,9 @@ jobs:
           command: |
             ./build.sh
       - persist_to_workspace:
-          root: secp256k1/build
+          root: secp256k1/build/lib
           paths:
-            - lib/libsecp256k1.so
+            - libsecp256k1.so*
       - store_artifacts:
           name: Linux native build artifacts
           path:  secp256k1/build/lib
@@ -96,9 +102,9 @@ jobs:
           command: |
             ./build.sh
       - persist_to_workspace:
-          root: secp256k1/build
+          root: secp256k1/build/lib
           paths:
-            - lib/libsecp256k1.dylib
+            - libsecp256k1.*dylib
       - store_artifacts:
           name: macOS native build artifacts
           path:  secp256k1/build/lib
@@ -106,8 +112,6 @@ jobs:
           when: always
   final-assembly:
     executor: besu_executor_med_linux
-    environment:
-      SKIP_GRADLE: true
     steps:
       - checkout_code
       - prepare_final_assembly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ commands:
 jobs:
   native-build-linux-x86-64:
     executor: besu_executor_med_linux
+    environment:
+      SKIP_GRADLE: true
     steps:
       - checkout_code
       - prepare_linux
@@ -84,6 +86,8 @@ jobs:
           when: always
   native-build-macos:
     executor: besu_executor_med_macos
+    environment:
+      SKIP_GRADLE: true
     steps:
       - checkout_code
       - prepare_macos
@@ -102,6 +106,8 @@ jobs:
           when: always
   final-assembly:
     executor: besu_executor_med_linux
+    environment:
+      SKIP_GRADLE: true
     steps:
       - checkout_code
       - prepare_final_assembly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,18 +57,8 @@ commands:
   prepare_final_assembly:
     description: "Prepare - Final Assembly"
     steps:
-      - run:
-          name: Install Packages - build tools
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y autoconf build-essential libtool
       - attach_workspace:
-          at: ~/project/secp256k1/build/lib
-      - run:
-          name: "Check workspace"
-          command: |
-            ls ~/project/secp256k1/build
-            ls ~/project/secp256k1/build/lib
+          at: secp256k1/build
 jobs:
   native-build-linux-x86-64:
     executor: besu_executor_med_linux
@@ -82,9 +72,9 @@ jobs:
           command: |
             ./build.sh
       - persist_to_workspace:
-          root: secp256k1/build/lib
+          root: secp256k1/build
           paths:
-            - libsecp256k1.so*
+            - lib/libsecp256k1.so*
       - store_artifacts:
           name: Linux native build artifacts
           path:  secp256k1/build/lib
@@ -102,9 +92,9 @@ jobs:
           command: |
             ./build.sh
       - persist_to_workspace:
-          root: secp256k1/build/lib
+          root: secp256k1/build
           paths:
-            - libsecp256k1.*dylib
+            - lib/libsecp256k1.*dylib
       - store_artifacts:
           name: macOS native build artifacts
           path:  secp256k1/build/lib
@@ -118,12 +108,26 @@ jobs:
       - run:
           name: gradle
           command: |
-            ./gradlew build
+            ./gradlew --no-daemon --parallel build
+      - persist_to_workspace:
+          root: secp256k1/build
+          paths:
+            - libs/*.jar
       - store_artifacts:
           name: Final build artifacts
           path: secp256k1/build/libs
           destination: secp256k1_jars
           when: always
+  publish:
+    executor: besu_executor_med_linux
+    steps:
+      - checkout_code
+      - attach_workspace:
+          at: secp256k1/build
+      - run:
+          name: Publish
+          command: |
+            ./gradlew --no-daemon --parallel bintrayUpload
 workflows:
   version: 2
   default:
@@ -134,4 +138,12 @@ workflows:
           requires:
             - native-build-linux-x86-64
             - native-build-macos
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - /^release-.*/
+          requires:
+            - final-assembly
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,45 +1,127 @@
 ---
 version: 2.1
 executors:
-  besu_executor_med: # 2cpu, 4G ram
+  besu_executor_med_linux: # 2cpu, 4G ram
     docker:
       - image: circleci/openjdk:11.0.4-jdk-stretch
     resource_class: medium
     working_directory: ~/project
     environment:
       GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+  besu_executor_med_macos: # 2cpu, 4G ram
+    macos:
+      xcode: "11.4.0"
+    resource_class: medium
+    working_directory: ~/project
+    environment:
+      GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+# besu_executor_med_windows: # 2cpu, 4G ram
+#   machine:
+#     image: "windows-server-2019-vs2019:stable"
+#     resource_class: medium
+#     shell: powershell.exe -ExecutionPolicy Bypass
+#   working_directory: ~/project
+#   environment:
+#     GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
-notify:
-  webhooks:
-    - url: https://hyperledger-rocket-chat-hubot.herokuapp.com/hubot/circleci
+#notify:
+#  webhooks:
+#    - url: https://hyperledger-rocket-chat-hubot.herokuapp.com/hubot/circleci
 
 commands:
-  prepare:
-    description: "Prepare"
+  checkout_code:
+    description: "Prepare - Checkout code"
     steps:
       - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update
+  prepare_linux:
+    description: "Prepare - Linux x86_64"
+    steps:
+      - run:
+          name: Install Packages - build tools
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y autoconf build-essential libtool
+  prepare_macos:
+    description: "Prepare - macOS"
+    steps:
+      - run:
+          name: Install Packages - build tools
+          command: |
+            brew install autoconf automake libtool
+  prepare_final_assembly:
+    description: "Prepare - Final Assembly"
+    steps:
+      - attach_workspace:
+          at: secp256k1/build
       - run:
           name: Install Packages - build tools
           command: |
             sudo apt-get update
             sudo apt-get install -y autoconf build-essential libtool
 jobs:
-  build:
-    executor: besu_executor_med
+  native-build-linux-x86-64:
+    executor: besu_executor_med_linux
     steps:
-      - prepare
+      - checkout_code
+      - prepare_linux
       - run:
           name: build
           command: |
             ./build.sh
+      - persist_to_workspace:
+          root: secp256k1/build
+          paths:
+            - lib/libsecp256k1.so
       - store_artifacts:
-          name: Native build artifacts
-          path:  secp256k1/built/lib
-          destination: secp256k1_native_artifacts
+          name: Linux native build artifacts
+          path:  secp256k1/build/lib
+          destination: secp256k1_linux_x86_64_native_artifacts
           when: always
-
+  native-build-macos:
+    executor: besu_executor_med_macos
+    steps:
+      - checkout_code
+      - prepare_macos
+      - run:
+          name: build
+          command: |
+            ./build.sh
+      - persist_to_workspace:
+          root: secp256k1/build
+          paths:
+            - lib/libsecp256k1.dylib
+      - store_artifacts:
+          name: macOS native build artifacts
+          path:  secp256k1/build/lib
+          destination: secp256k1_macOS_native_artifacts
+          when: always
+  final-assembly:
+    executor: besu_executor_med_linux
+    steps:
+      - checkout_code
+      - prepare_final_assembly
+      - run:
+          name: gradle
+          command: |
+            ./gradlew build
+      - store_artifacts:
+          name: Final build artifacts
+          path: secp256k1/build/libs
+          destination: secp256k1_jars
+          when: always
 workflows:
   version: 2
   default:
     jobs:
-      - build
+      - native-build-linux-x86-64
+      - native-build-macos
+      - final-assembly:
+          requires:
+            - native-build-linux-x86-64
+            - native-build-macos
+

--- a/build.sh
+++ b/build.sh
@@ -61,8 +61,10 @@ fi
 
 # kick off gradle build to package and deploy jars
 
-cd $SCRIPTDIR
-./gradlew build
+if [[ "$SKIP_GRADLE" != "" ]]; then
+  cd $SCRIPTDIR
+  ./gradlew build
+fi
 
 #############################
 #### end secp256k1 build ####

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,8 @@ SECP256K1_BUILD_OPTS="--enable-module-recovery"
 ####### End Variables #######
 #############################
 
+SKIP_GRADLE=${SKIP_GRADLE:""}
+
 # Exit script if you try to use an uninitialized variable.
 set -o nounset
 
@@ -61,7 +63,7 @@ fi
 
 # kick off gradle build to package and deploy jars
 
-if [[ "$SKIP_GRADLE" != "" ]]; then
+if [ -z "$SKIP_GRADLE" ]; then
   cd $SCRIPTDIR
   ./gradlew build
 fi

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,8 @@ SECP256K1_BUILD_OPTS="--enable-module-recovery"
 ####### End Variables #######
 #############################
 
-SKIP_GRADLE=${SKIP_GRADLE:""}
+# Initialize external vars - need this to get around unbound variable errors
+SKIP_GRADLE="$SKIP_GRADLE"
 
 # Exit script if you try to use an uninitialized variable.
 set -o nounset
@@ -63,7 +64,7 @@ fi
 
 # kick off gradle build to package and deploy jars
 
-if [ -z "$SKIP_GRADLE" ]; then
+if [[ "$SKIP_GRADLE" != "true" ]]; then
   cd $SCRIPTDIR
   ./gradlew build
 fi

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -31,7 +31,7 @@ task macLibCopy(type: Copy) {
 jar.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
-  from '//FIXME'
+  from 'build/lib/libsecp256k1.so'
   into 'build/resources/main/linux-x86-64'
 }
 jar.dependsOn linuxLibCopy

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -16,7 +16,7 @@
 plugins {
   id 'java-library'
   id 'maven-publish'
-//  id 'com.jfrog.bintray'
+  id 'com.jfrog.bintray' version '1.8.4'
 }
 
 dependencies {
@@ -59,6 +59,29 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 
+apply plugin: 'com.jfrog.bintray'
+
+def bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+def bintrayKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_KEY')
+
+// These are made able to be overridden so that we can test publishing to a test repo
+def bintrayRepo = System.getenv('BINTRAY_REPO') != "" ? System.getenv('BINTRAY_REPO') : 'besu-repo'
+def bintrayOrg = System.getenv('BINTRAY_ORG') != "" ? System.getenv('BINTRAY_ORG') : 'hyperledger-org'
+
+def bintrayPackage = bintray.pkg {
+  repo = bintrayRepo
+  name = 'besu-native-secp256k1'
+  userOrg = bintrayOrg
+  licenses = ['Apache-2.0']
+  websiteUrl = 'https://github.com/hyperledger/besu-native'
+  vcsUrl = 'https://github.com/hyperledger/besu-native.git'
+
+  version {
+    name = project.version
+    released = new Date()
+  }
+}
+
 publishing {
   publications {
     mavenJava(MavenPublication) {
@@ -72,7 +95,7 @@ publishing {
       pom {
         name = "Besu Native - ${project.name}"
         description = 'Adapter for native secp256k1 library'
-        url = 'http://github.com/hyperledger/besu'
+        url = 'http://github.com/hyperledger/besu-native'
         licenses {
           license {
             name = 'The Apache License, Version 2.0'
@@ -80,24 +103,24 @@ publishing {
           }
         }
         scm {
-          connection = 'scm:git:git://github.com/hyperledger/besu.git'
-          developerConnection = 'scm:git:ssh://github.com/hyperledger/besu.git'
-          url = 'https://github.com/hyperledger/besu'
+          connection = 'scm:git:git://github.com/hyperledger/besu-native.git'
+          developerConnection = 'scm:git:ssh://github.com/hyperledger/besu-native.git'
+          url = 'https://github.com/hyperledger/besu-native'
         }
       }
     }
   }
 }
 
-//bintray {
-//  user = bintrayUser
-//  key = bintrayKey
-//
-//  publications = ['mavenJava']
-//  override = version.endsWith('SNAPSHOT')
-//
-//  publish = true
-//
-//  pkg = bintrayPackage
-//}
-//
+bintray {
+  user = bintrayUser
+  key = bintrayKey
+
+  publications = ['mavenJava']
+  override = version.endsWith('SNAPSHOT')
+
+  publish = true
+
+  pkg = bintrayPackage
+}
+

--- a/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
+++ b/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
@@ -28,38 +28,29 @@ import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
 
-public interface LibSecp256k1 extends Library {
+public class LibSecp256k1 implements Library {
 
   /* Flags to pass to secp256k1_context_create */
-  int SECP256K1_CONTEXT_VERIFY = 0x0101;
-  int SECP256K1_CONTEXT_SIGN = 0x0201;
+  public static final int SECP256K1_CONTEXT_VERIFY = 0x0101;
+  public static final int SECP256K1_CONTEXT_SIGN = 0x0201;
 
   /* Flag to pass to secp256k1_ec_pubkey_serialize. */
-  int SECP256K1_EC_COMPRESSED = 0x0001;
-  int SECP256K1_EC_UNCOMPRESSED = 0x0002;
+  public static final int SECP256K1_EC_UNCOMPRESSED = 0x0002;
 
-  LibSecp256k1 INSTANCE = findInstance();
-  PointerByReference CONTEXT = createContext();
-
-  private static LibSecp256k1 findInstance() {
-    try {
-      return Native.load("secp256k1", LibSecp256k1.class);
-    } catch (final Throwable t) {
-      return null;
-    }
-  }
+  public static final PointerByReference CONTEXT = createContext();
 
   private static PointerByReference createContext() {
-    if (INSTANCE == null) {
-      return null;
-    } else {
+    try {
+      Native.register(LibSecp256k1.class, "secp256k1");
       final PointerByReference context =
-          INSTANCE.secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
-      if (INSTANCE.secp256k1_context_randomize(context, new SecureRandom().generateSeed(32)) == 1) {
+          secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
+      if (secp256k1_context_randomize(context, new SecureRandom().generateSeed(32)) == 1) {
         return context;
       } else {
         return null;
       }
+    } catch (final Throwable t) {
+      return null;
     }
   }
 
@@ -69,7 +60,7 @@ public interface LibSecp256k1 extends Library {
    * <p>Except for test cases, this function should compute some cryptographic hash of the message,
    * the algorithm, the key and the attempt.
    */
-  interface secp256k1_nonce_function extends Callback {
+  public interface secp256k1_nonce_function extends Callback {
 
     /**
      * @param nonce32 (output) Pointer to a 32-byte array to be filled by the function.
@@ -95,7 +86,7 @@ public interface LibSecp256k1 extends Library {
    * transmission, or comparison, use secp256k1_ec_pubkey_serialize and secp256k1_ec_pubkey_parse.
    */
   @FieldOrder({"data"})
-  class secp256k1_pubkey extends Structure {
+  public static class secp256k1_pubkey extends Structure {
     public byte[] data = new byte[64];
   }
 
@@ -109,7 +100,7 @@ public interface LibSecp256k1 extends Library {
    * secp256k1_ecdsa_signature_parse_* functions.
    */
   @FieldOrder({"data"})
-  class secp256k1_ecdsa_signature extends Structure {
+  public static class secp256k1_ecdsa_signature extends Structure {
     public byte[] data = new byte[64];
   }
 
@@ -126,7 +117,7 @@ public interface LibSecp256k1 extends Library {
    * will have identical representation, so they can be memcmp'ed.
    */
   @FieldOrder({"data"})
-  class secp256k1_ecdsa_recoverable_signature extends Structure {
+  public static class secp256k1_ecdsa_recoverable_signature extends Structure {
     public byte[] data = new byte[65];
   }
 
@@ -142,7 +133,7 @@ public interface LibSecp256k1 extends Library {
    * @param flags which parts of the context to initialize.
    * @return a newly created context object.
    */
-  PointerByReference secp256k1_context_create(final int flags);
+  public static native PointerByReference secp256k1_context_create(final int flags);
 
   /**
    * Parse a variable-length public key into the pubkey object.
@@ -159,7 +150,7 @@ public interface LibSecp256k1 extends Library {
    * @param input pointer to a serialized public key
    * @param inputlen length of the array pointed to by input
    */
-  int secp256k1_ec_pubkey_parse(
+  public static native int secp256k1_ec_pubkey_parse(
       final PointerByReference ctx,
       final secp256k1_pubkey pubkey,
       final byte[] input,
@@ -178,7 +169,7 @@ public interface LibSecp256k1 extends Library {
    * @param flags SECP256K1_EC_COMPRESSED if serialization should be in compressed format, otherwise
    *     SECP256K1_EC_UNCOMPRESSED.
    */
-  int secp256k1_ec_pubkey_serialize(
+  public static native int secp256k1_ec_pubkey_serialize(
       final PointerByReference ctx,
       final ByteBuffer output,
       final LongByReference outputlen,
@@ -200,7 +191,7 @@ public interface LibSecp256k1 extends Library {
    * @param sig (output) a pointer to a signature object
    * @param input64 a pointer to the 64-byte array to parse
    */
-  int secp256k1_ecdsa_signature_parse_compact(
+  public static native int secp256k1_ecdsa_signature_parse_compact(
       final PointerByReference ctx, final secp256k1_ecdsa_signature sig, final byte[] input64);
 
   /**
@@ -220,7 +211,7 @@ public interface LibSecp256k1 extends Library {
    * @param msg32 the 32-byte message hash being verified (cannot be NULL)
    * @param pubkey pointer to an initialized public key to verify with (cannot be NULL)
    */
-  int secp256k1_ecdsa_verify(
+  public static native int secp256k1_ecdsa_verify(
       final PointerByReference ctx,
       final secp256k1_ecdsa_signature sig,
       final byte[] msg32,
@@ -234,7 +225,7 @@ public interface LibSecp256k1 extends Library {
    * @param pubkey (output) pointer to the created public key (cannot be NULL)
    * @param seckey pointer to a 32-byte private key (cannot be NULL)
    */
-  int secp256k1_ec_pubkey_create(
+  public static native int secp256k1_ec_pubkey_create(
       final PointerByReference ctx, final secp256k1_pubkey pubkey, final byte[] seckey);
 
   /**
@@ -261,7 +252,8 @@ public interface LibSecp256k1 extends Library {
    * @return Returns 1 if randomization successfully updated or nothing to randomize or 0 if an
    *     error occured
    */
-  int secp256k1_context_randomize(final PointerByReference ctx, final byte[] seed32);
+  public static native int secp256k1_context_randomize(
+      final PointerByReference ctx, final byte[] seed32);
 
   /**
    * Parse a compact ECDSA signature (64 bytes + recovery id).
@@ -272,7 +264,7 @@ public interface LibSecp256k1 extends Library {
    * @param input64 a pointer to a 64-byte compact signature
    * @param recid the recovery id (0, 1, 2 or 3)
    */
-  int secp256k1_ecdsa_recoverable_signature_parse_compact(
+  public static native int secp256k1_ecdsa_recoverable_signature_parse_compact(
       final PointerByReference ctx,
       final secp256k1_ecdsa_recoverable_signature sig,
       final byte[] input64,
@@ -286,7 +278,7 @@ public interface LibSecp256k1 extends Library {
    * @param recid (output) a pointer to an integer to hold the recovery id (can be NULL).
    * @param sig a pointer to an initialized signature object (cannot be NULL)
    */
-  void secp256k1_ecdsa_recoverable_signature_serialize_compact(
+  public static native void secp256k1_ecdsa_recoverable_signature_serialize_compact(
       final PointerByReference ctx,
       final ByteBuffer output64,
       final IntByReference recid,
@@ -305,7 +297,7 @@ public interface LibSecp256k1 extends Library {
    *     secp256k1_nonce_function_default is used
    * @param ndata pointer to arbitrary data used by the nonce generation function (can be NULL)
    */
-  int secp256k1_ecdsa_sign_recoverable(
+  public static native int secp256k1_ecdsa_sign_recoverable(
       final PointerByReference ctx,
       final secp256k1_ecdsa_recoverable_signature sig,
       final byte[] msg32,
@@ -323,7 +315,7 @@ public interface LibSecp256k1 extends Library {
    * @param sig pointer to initialized signature that supports pubkey recovery (cannot be NULL)
    * @param msg32 the 32-byte message hash assumed to be signed (cannot be NULL)
    */
-  int secp256k1_ecdsa_recover(
+  public static native int secp256k1_ecdsa_recover(
       final PointerByReference ctx,
       final secp256k1_pubkey pubkey,
       final secp256k1_ecdsa_recoverable_signature sig,


### PR DESCRIPTION
Includes changes to the CircleCI configs to support building native dependencies across Linux (x86_64), and macOS. Will update in a future PR with support for Linux (ARM32) and Windows.

Signed-off-by: Ben Burns <803016+benjamincburns@users.noreply.github.com>
Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>