### PR TITLE
MacOSX tweak

### DIFF
--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 task macLibCopy(type: Copy) {
   from 'build/lib/libsecp256k1.dylib'
   into 'build/resources/main/darwin'
-  rename(/(\w+)\.dylib/, '$1.jnilib')
 }
 jar.dependsOn macLibCopy
 


### PR DESCRIPTION
Turns out it doesn't require the jnilib.  In fact, it doesn't even search for it.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>