### PR TITLE
Add EIP196/197 methods to matterlabs library

### DIFF
--- a/bls12-381/src/main/java/org/hyperledger/besu/nativelib/bls12_381/LibEthPairings.java
+++ b/bls12-381/src/main/java/org/hyperledger/besu/nativelib/bls12_381/LibEthPairings.java
@@ -20,6 +20,7 @@ import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
 
 public class LibEthPairings implements Library {
+  @SuppressWarnings("WeakerAccess")
   public static final boolean ENABLED;
 
   static {
@@ -55,4 +56,21 @@ public class LibEthPairings implements Library {
       IntByReference o_len,
       byte[] err,
       IntByReference err_len);
+
+  public static final int EIP196_PREALLOCATE_FOR_ERROR_BYTES = 256;
+
+  public static final int EIP196_PREALLOCATE_FOR_RESULT_BYTES = 64;
+
+  public static final byte EIP196_ADD_OPERATION_RAW_VALUE = 1;
+  public static final byte EIP196_MUL_OPERATION_RAW_VALUE = 2;
+  public static final byte EIP196_PAIR_OPERATION_RAW_VALUE = 3;
+
+  public static native int eip196_perform_operation(
+      byte op,
+      byte[] i,
+      int i_len,
+      byte[] o,
+      IntByReference o_len,
+      byte[] err,
+      IntByReference char_len);
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.2.1-SNAPSHOT
+version=0.3.0-SNAPSHOT


### PR DESCRIPTION
Ad EIP 196 (BN add/mul) and EIP197 (BN pairing).  Performance is notably
better than the sputnikvm code.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>