### PR TITLE
use non-blocking PRNG to generate secp256k1 context

### DIFF
--- a/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
+++ b/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
@@ -16,7 +16,7 @@
 package org.hyperledger.besu.nativelib.secp256k1;
 
 import java.nio.ByteBuffer;
-import java.security.SecureRandom;
+import java.util.Random;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
@@ -46,7 +46,9 @@ public class LibSecp256k1 implements Library {
           secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
       if (Boolean.parseBoolean(System.getProperty("secp256k1.randomize", "true"))) {
         // randomization requested or not explicitly disabled
-        if (secp256k1_context_randomize(context, new SecureRandom().generateSeed(32)) != 1) {
+        byte[] seed = new byte[32];
+        (new Random()).nextBytes(seed);
+        if (secp256k1_context_randomize(context, seed) != 1) {
           // there was an error, don't preserve the context
           return null;
         }


### PR DESCRIPTION
This uses `java.util.Random.nextBytes` instead of `java.security.SecureRandom.generateSeed` to generate the seed used to "randomize" the secp256k1 context. The later might block indefinitely on some platforms when the OS' RNG runs out of entropy.

`java.util.Random` is a much weaker source of randomness (2^48 cycle, much less under real world conditions due to imperfect seed). It is however sufficient in this case: The context randomization is only used as an additional precaution against side channel attacks in case the compiler ruins the constant time property of the underlying code.

Signed-off-by: Taccat Isid <taccatisid@protonmail.com>