### PR TITLE
Padding of the R and S components in case they are smaller than 31 bytes for SECP256r1

### DIFF
--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
@@ -118,7 +118,7 @@ public class LibSECP256R1 {
         if (signature.length < CURVE_BYTE_LENGTH) {
             byte[] nativeSignature = new byte[CURVE_BYTE_LENGTH];
 
-            // copy signature to nativeSignature, shifting it one to the right
+            // copy signature to nativeSignature, shifting it to the right
             System.arraycopy(signature, 0, nativeSignature, CURVE_BYTE_LENGTH - signature.length, signature.length);
 
             return nativeSignature;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
@@ -113,13 +113,13 @@ public class LibSECP256R1 {
             return nativeSignature;
         }
 
-        // the first byte in the native representation was 0, but in the Java representation this is ignored.
+        // the first bytes in the native representation were 0, but in the Java representation this is ignored.
         // the signature needs to be shifted to the right for the native representation
-        if (signature.length == CURVE_BYTE_LENGTH - 1) {
+        if (signature.length < CURVE_BYTE_LENGTH) {
             byte[] nativeSignature = new byte[CURVE_BYTE_LENGTH];
 
             // copy signature to nativeSignature, shifting it one to the right
-            System.arraycopy(signature, 0, nativeSignature, 1, signature.length);
+            System.arraycopy(signature, 0, nativeSignature, CURVE_BYTE_LENGTH - signature.length, signature.length);
 
             return nativeSignature;
         }

--- a/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
+++ b/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
@@ -16,9 +16,11 @@
 package org.hyperledger.besu.nativelib.secp256r1;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.assertj.core.util.Hexadecimals;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -90,6 +92,25 @@ public class LibSECP256R1Test {
         );
 
         assertThat(actualPublicKey).isEqualTo(publicKey.toArrayUnsafe());
+
+    }
+
+    @Test
+    public void keyRecovery_should_return_expected_public_key_if_r_is_not_32_bytes_long() {
+        final BigInteger r = new BigInteger("607232317131644998607993399928086035368869502933999419429470745918733484");
+        final BigInteger s = new BigInteger("909326537358980219114547956988636184748037502936154044628658501523731230682");
+        final byte v = (byte) 1;
+        final Bytes dataHash = Bytes.fromHexString("0x5d2a686cbe81873192db62f069cc1f0c10a1580c89d19c21407dcd1cde48ad06");
+
+
+        byte[] actualPublicKey = libSecp256r1.keyRecovery(
+                dataHash.toArrayUnsafe(),
+                r.toByteArray(),
+                s.toByteArray(),
+                v
+        );
+
+        assertThat(Hexadecimals.toHexString(actualPublicKey)).isEqualTo("0x33f004f357282e13036385d3f52a90f5e62fa0d51c39dff99cb72fd06cb5fab72f2dc5e05786154dd7a349dc3fdd9be2f0b9665c4e08fa6cdc1fd447112acf3f");
 
     }
 

--- a/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
+++ b/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
@@ -110,8 +110,7 @@ public class LibSECP256R1Test {
                 v
         );
 
-        assertThat(Hexadecimals.toHexString(actualPublicKey)).isEqualTo("0x33f004f357282e13036385d3f52a90f5e62fa0d51c39dff99cb72fd06cb5fab72f2dc5e05786154dd7a349dc3fdd9be2f0b9665c4e08fa6cdc1fd447112acf3f");
-
+        assertThat(Hexadecimals.toHexString(actualPublicKey)).isEqualTo("33F004F357282E13036385D3F52A90F5E62FA0D51C39DFF99CB72FD06CB5FAB72F2DC5E05786154DD7A349DC3FDD9BE2F0B9665C4E08FA6CDC1FD447112ACF3F");
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
+++ b/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
@@ -96,7 +96,7 @@ public class LibSECP256R1Test {
     }
 
     @Test
-    public void keyRecovery_should_return_expected_public_key_if_r_is_not_32_bytes_long() {
+    public void keyRecovery_should_return_expected_public_key_if_r_is_less_than_32_bytes_long() {
         final BigInteger r = new BigInteger("607232317131644998607993399928086035368869502933999419429470745918733484");
         final BigInteger s = new BigInteger("909326537358980219114547956988636184748037502936154044628658501523731230682");
         final byte v = (byte) 1;


### PR DESCRIPTION
_Note from @NicolasMassart (Consensys Customer Support):
This PR if from one of the Consensys customers directly. I removed the internal reference to our ticketing system as it's not useful to HL community as they don't have access. The PR is well referenced in the ticket on our side._

## Description of the issue

Sometimes the signature components (in that case it was R) are 30-bytes long and both the keys and the signatures are still valid.

The values added in the unit test are taken from one of the actual errors shown in the error logs:

```
2022-01-19 17:39:09.672+00:00 | EthScheduler-Workers-1 | INFO  | PersistBlockTask | Imported #591,672 / 22 tx / 0 om / 784,208 (0.0%) gas / (0x14eb9590af60f2e86d4a617bb34e8de4255b35819cfbb8a1a87dc0cbbc021b21) in 0.065s. Peers: 4
2022-01-19 17:39:10.032+00:00 | vert.x-worker-thread-3 | ERROR | JsonRpcHttpService | Error processing JSON-RPC requestBody
java.lang.IllegalStateException: Cannot recover public key from signature for MessageCall{type=FRONTIER, nonce=354537, gasPrice=0x0, gasLimit=900000, to=0x4bdf5ccc513a0f4c9e70f8e22dc572c6a3ce93f3, value=0x0000000000000000000000000000000000000000000000000000000000000000, sig=Signature{r=607232317131644998607993399928086035368869502933999419429470745918733484, s=909326537358980219114547956988636184748037502936154044628658501523731230682, recId=1}, payload=0x2b96ec34000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000ce080112a3010a14d4e799019fb8850f5532baafb57302ae7ad4daad1220c57f3ba81cb7fd341e18dcbbf29ee2e1de8fa0253099304f7fd92088b895f5d51a473045022100ef44c089e8e099cabea07b002985876c543194b0bc00415fef8cee5b8f6e8e6b02205580d481f79fb1f6ee2b541738b79481d89c159c3c39cd9b438d3e52c29065122220088116856e9d1d554d9f0d51de6405b25d1f5eabca81f7a3781145830f975a4f2a2431643265633838612d626431372d343565342d383535622d653962656536363565666331000000000000000000000000000000000000}
	at org.hyperledger.besu.ethereum.core.Transaction.lambda$getSender$3(Transaction.java:517)
	at java.base/java.util.Optional.orElseThrow(Optional.java:408)
	at org.hyperledger.besu.ethereum.core.Transaction.getSender(Transaction.java:515)
	at org.hyperledger.besu.ethereum.mainnet.MainnetTransactionValidator.validateTransactionSignature(MainnetTransactionValidator.java:257)
	at org.hyperledger.besu.ethereum.mainnet.MainnetTransactionValidator.validate(MainnetTransactionValidator.java:111)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.validateTransaction(TransactionPool.java:240)
	at org.hyperledger.besu.ethereum.eth.transactions.TransactionPool.addLocalTransaction(TransactionPool.java:135)
	at org.hyperledger.besu.ethereum.api.jsonrpc.internal.methods.EthSendRawTransaction.response(EthSendRawTransaction.java:79)
	at org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcHttpService.process(JsonRpcHttpService.java:748)
	at org.hyperledger.besu.ethereum.api.jsonrpc.JsonRpcHttpService.lambda$handleJsonSingleRequest$14(JsonRpcHttpService.java:608)
	at io.vertx.core.impl.ContextImpl.lambda$null$0(ContextImpl.java:159)
	at io.vertx.core.impl.AbstractContext.dispatch(AbstractContext.java:100)
	at io.vertx.core.impl.ContextImpl.lambda$executeBlocking$1(ContextImpl.java:157)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
2022-01-19 17:39:11.668+00:00 | EthScheduler-Workers-1 | INFO  | PersistBlockTask | Imported #591,673 / 11 tx / 0 om / 392,072 (0.0%) gas / (0xda0059d5397a909d9f7ffd5b178e323da9f3623a36eb0d60843209ff8d8ab894) in 0.036s. Peers: 4
```

There is [another test created in this fork on an upper level for Besu](https://github.com/freemanzMrojo/besu/blob/test-signature-r-padded-r1/crypto/src/test/java/org/hyperledger/besu/crypto/SECP256R1Test.java#L150) checking precisely the same as this test.

## Fix

Add proper padding to signatures

Signed-off by: miguelangel.rojofernandez@mastercard.com