### PR TITLE
update rust versions to 1.62.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,6 @@ commands:
             # rust dependencies
             export CARGO_HOME="$HOME/.cargo"
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.61.1
-            rustup target add x86_64-unknown-linux-gnu
-            rustup target add aarch64-unknown-linux-gnu
   prepare_macos:
     description: "Prepare - macOS"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ commands:
             sudo apt-get install -y autoconf build-essential libtool automake patchelf
             # rust dependencies
             export CARGO_HOME="$HOME/.cargo"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.61.1
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.62.1
   prepare_macos:
     description: "Prepare - macOS"
     steps:
@@ -66,7 +66,7 @@ commands:
             brew install autoconf automake libtool
             # rust dependencies
             export CARGO_HOME="$HOME/.cargo"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.61.1
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.62.1
             # install both x86 and arm64 toolchains
             export PATH="$HOME/.cargo/bin:$PATH"
             rustup target add x86_64-apple-darwin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,9 @@ commands:
             sudo apt-get install -y autoconf build-essential libtool automake patchelf
             # rust dependencies
             export CARGO_HOME="$HOME/.cargo"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.53.0
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.61.1
+            rustup target add x86_64-unknown-linux-gnu
+            rustup target add aarch64-unknown-linux-gnu
   prepare_macos:
     description: "Prepare - macOS"
     steps:
@@ -66,7 +68,7 @@ commands:
             brew install autoconf automake libtool
             # rust dependencies
             export CARGO_HOME="$HOME/.cargo"
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.53.0
+            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.61.1
             # install both x86 and arm64 toolchains
             export PATH="$HOME/.cargo/bin:$PATH"
             rustup target add x86_64-apple-darwin


### PR DESCRIPTION
Update rust versions to 1.62.1 so that ipa-multipoint can compile.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>