### PR TITLE
0.6.1 release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-# 0.6.1-SNAPSHOT
+# 0.6.1
+
+* Update to latest jna, use separate build folders per os/arch [#79](https://github.com/hyperledger/besu-native/pull/79)
+* Add linux arm64 build of bls12-381 [#81](https://github.com/hyperledger/besu-native/pull/81), [#80](https://github.com/hyperledger/besu-native/pull/80)
+* Restrict builds of blake2f to x86-64 [#82](https://github.com/hyperledger/besu-native/pull/82) 
 
 # 0.6.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.6.1-SNAPSHOT
+version=0.6.1


### PR DESCRIPTION
0.6.1 release includes:

* Update to jna 5.12.1
* Add linux arm64 build of bls12-381 
* Restrict builds of blake2f to x86-64 

Signed-off-by: garyschulte <garyschulte@gmail.com>