### PR TITLE
Restore Mac ECDSA libs

### DIFF
--- a/altbn128/build.gradle
+++ b/altbn128/build.gradle
@@ -23,9 +23,15 @@ dependencies {
   implementation 'net.java.dev.jna:jna:5.12.1'
 }
 
+task macArmLibCopy(type: Copy) {
+  from 'build/darwin-aarch64/lib/libeth_altbn128.dylib'
+  into 'build/resources/main/darwin-aarch64'
+}
+jar.dependsOn macArmLibCopy
+
 task macLibCopy(type: Copy) {
-  from 'build/darwin/lib/libeth_altbn128.dylib'
-  into 'build/resources/main/darwin'
+  from 'build/darwin-x86-64/lib/libeth_altbn128.dylib'
+  into 'build/resources/main/darwin-x86-64'
 }
 jar.dependsOn macLibCopy
 

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -23,9 +23,15 @@ dependencies {
   implementation 'net.java.dev.jna:jna:5.12.1'
 }
 
+task macArmLibCopy(type: Copy) {
+  from 'build/darwin-aarch64/lib/libsecp256k1.dylib'
+  into 'build/resources/main/darwin-aarch64'
+}
+jar.dependsOn macArmLibCopy
+
 task macLibCopy(type: Copy) {
-  from 'build/darwin/lib/libsecp256k1.dylib'
-  into 'build/resources/main/darwin'
+  from 'build/darwin-x86-64/lib/libsecp256k1.dylib'
+  into 'build/resources/main/darwin-x86-64'
 }
 jar.dependsOn macLibCopy
 

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -28,10 +28,17 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
+task macArmLibCopy(type: Copy) {
+    from 'besu-native-ec/release/darwin-aarch64/libbesu_native_ec.dylib'
+    from 'besu-native-ec/release/darwin-aarch64/libbesu_native_ec_crypto.dylib'
+    into 'build/resources/main/darwin-aarch64'
+}
+jar.dependsOn macArmLibCopy
+
 task macLibCopy(type: Copy) {
-    from 'besu-native-ec/release/darwin/libbesu_native_ec.dylib'
-    from 'besu-native-ec/release/darwin/libbesu_native_ec_crypto.dylib'
-    into 'build/resources/main/darwin'
+    from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec.dylib'
+    from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec_crypto.dylib'
+    into 'build/resources/main/darwin-x86-64'
 }
 jar.dependsOn macLibCopy
 


### PR DESCRIPTION
Restore the generation of the two ECDSA libs in the new darwin-<arch> format.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>