### PR TITLE
Use specific CI OS versions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   native-build-linux-x86-64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       SKIP_GRADLE: true
     steps:
@@ -95,7 +95,7 @@ jobs:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
   native-build-macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     env:
       SKIP_GRADLE: true
     steps:
@@ -184,7 +184,7 @@ jobs:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
   final-assembly:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - native-build-macos
       - native-build-m1


### PR DESCRIPTION
Github Actions recently migrated the major versions of ubuntu and macosx for its standard builders. This "stealth" upgrade made the 0.7.0 release unsuitable for CI use as it started depending on newer versions
 of glibc.

 Fix the versions of ubuntu and macos to pre-october values.
