### PR TITLE
Change coordinates from native to nativelib

### DIFF
--- a/altbn128/build.gradle
+++ b/altbn128/build.gradle
@@ -56,7 +56,7 @@ jar {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
-        'Automatic-Module-Name': 'org.hyperledger.besu.native.altbn128'
+        'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.altbn128'
     )
   }
 }

--- a/arithmetic/build.gradle
+++ b/arithmetic/build.gradle
@@ -63,7 +63,7 @@ jar {
                 'Specification-Version': project.version,
                 'Implementation-Title': archiveBaseName,
                 'Implementation-Version': project.version,
-                'Automatic-Module-Name': 'org.hyperledger.besu.native.arithmetic'
+                'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.arithmetic'
         )
     }
 }

--- a/blake2bf/build.gradle
+++ b/blake2bf/build.gradle
@@ -60,7 +60,7 @@ jar {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
-        'Automatic-Module-Name': 'org.hyperledger.besu.native.blake2bf'
+        'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.blake2bf'
     )
   }
 }

--- a/bls12-381/build.gradle
+++ b/bls12-381/build.gradle
@@ -60,7 +60,7 @@ jar {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
-        'Automatic-Module-Name': 'org.hyperledger.besu.native.bls12_381'
+        'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.bls12_381'
     )
   }
 }

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -61,7 +61,7 @@ jar {
                 'Specification-Version': project.version,
                 'Implementation-Title': archiveBaseName,
                 'Implementation-Version': project.version,
-                'Automatic-Module-Name': 'org.hyperledger.besu.native.gnark'
+                'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.gnark'
         )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.7.2-SNAPSHOT
+version=0.8.0-SNAPSHOT

--- a/ipa-multipoint/build.gradle
+++ b/ipa-multipoint/build.gradle
@@ -60,7 +60,7 @@ jar {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
-        'Automatic-Module-Name': 'org.hyperledger.besu.native.ipa.multipoint'
+        'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.ipa.multipoint'
     )
   }
 }

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -56,7 +56,7 @@ jar {
         'Specification-Version': project.version,
         'Implementation-Title': archiveBaseName,
         'Implementation-Version': project.version,
-        'Automatic-Module-Name': 'org.hyperledger.besu.native.secp256k1'
+        'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.secp256k1'
     )
   }
 }

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -65,7 +65,7 @@ jar {
                 'Specification-Version': project.version,
                 'Implementation-Title': archiveBaseName,
                 'Implementation-Version': project.version,
-                'Automatic-Module-Name': 'org.hyperledger.besu.native.secp256r1'
+                'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.secp256r1'
         )
     }
 }


### PR DESCRIPTION
Migrate all maven coordinates that were `.native.` to `.nativelib.`. The old coordinate name presented problems in some auto-module systems for the JPMS.