### PR TITLE
disable blake tests on arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,6 @@ jobs:
           brew install autoconf automake libtool
           # gnark dependencies
           brew install go@1.20 || true
-          export PATH=/usr/local/Cellar/go/1.20.2/bin:$PATH
           # rust dependencies
           export CARGO_HOME="$HOME/.cargo"
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.68.2
@@ -174,11 +173,20 @@ jobs:
     steps:
       - name: Prepare
         run: |
+          # check for homebrew and install from known sha if it is missing (like on macstadium)
+          if ! command -v brew &> /dev/null
+          then
+            # get pwd for homebrew:
+            export HOMEBREW_PREFIX=`pwd`/../homebrew
+            # use local homebrew 4.0.26 release, as brew is not available on macstadium:
+            mkdir -p $HOMEBREW_PREFIX && curl -L https://github.com/Homebrew/brew/tarball/eff45ef570f265e226f14ce91da72d7a6e7d516a| tar xz --strip 1 -C $HOMEBREW_PREFIX
+            export PATH=$HOMEBREW_PREFIX/bin:$PATH
+            echo "HOMEBREW_BIN=$HOMEBREW_PREFIX/bin" >> $GITHUB_ENV
+          fi
           # secp256k1, gnark dependencies
-          brew install autoconf automake libtool 
+          brew install autoconf automake libtool
           # gnark dependencies
           brew install go@1.20 || true 
-          export PATH=/usr/local/Cellar/go/1.20.2/bin:$PATH
           # rust dependencies
           export CARGO_HOME="$HOME/.cargo"
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.68.2
@@ -190,8 +198,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 17
+          cache: gradle
       - name: Build
-        run: ./build.sh
+        run: |
+          export HOMEBREW_BIN=${{ env.HOMEBREW_BIN }}
+          export PATH=$HOMEBREW_BIN:$PATH
+          ./build.sh
       - uses: actions/upload-artifact@v3.1.0
         with:
           name: altbn128 native build artifacts
@@ -278,7 +295,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: 11
+          java-version: 17
           cache: gradle
       - name: gradle build
         uses: gradle/gradle-build-action@v2

--- a/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
+++ b/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
@@ -15,9 +15,11 @@
 package org.hyperledger.besu.nativelib.blake2bf;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.util.Arrays;
 import java.util.Collection;
+
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,6 +73,7 @@ public class LibBlake2bfTest {
 
   @Test
   public void eip152TestCases() {
+    Assume.assumeFalse(System.getProperty("os.arch").equals("aarch64"));
     byte[] out = new byte[64];
     messageDigest.blake2bf_eip152(out, input);
     assertThat(out).isEqualTo(expected);


### PR DESCRIPTION
Since the native blake2bf implementation is slower than the java implementation on arm64, it is not being built:
https://github.com/hyperledger/besu-native/blob/main/build.sh#L69-L76

Ignore this test if we are running on arm64.  Tested on OSX

edit: Also address CI breakage with this PR.  
fixes #110 