### PR TITLE
FIX: javadoc problems, removes <-> chars

### DIFF
--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -60,8 +60,8 @@ public class LibIpaMultipoint {
 
   /**
    * Pedersen hash as specified in https://notes.ethereum.org/@vbuterin/verkle_tree_eip
-   * @param input Expects 64byte value as input encoded as byte[] e.g. "0x000..." <-> [48,48,48...] (48 is 0 in ASCII)
-   * @return 32bytes as byte[]  "0x000..." <-> [48,48,48...] (48 is 0 in ASCII)
+   * @param input Expects 64byte value as input encoded as byte[]
+   * @return 32bytes as byte[]
    */
   public static native byte[] pedersenHash(byte[] input);
 }


### PR DESCRIPTION
Javadoc was failing because of HTML-incompatible characters.
They were removed