### PR TITLE
Add support for MiMC on BLS12-377's scalar field

### DIFF
--- a/gnark/gnark-jni/gnark-jni.go
+++ b/gnark/gnark-jni/gnark-jni.go
@@ -1,28 +1,41 @@
 package main
 
-
-
 import "C"
-import "unsafe"
 import (
-	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
+	"unsafe"
+
+	mimcBls12377 "github.com/consensys/gnark-crypto/ecc/bls12-377/fr/mimc"
+	mimcBn254 "github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 )
 
-func MiMCHash(b []byte) []byte {
-     hasher := mimc.NewMiMC()
-     hasher.Write(b)
-     return hasher.Sum(nil)
+func MiMCBls12377Hash(b []byte) []byte {
+	hasher := mimcBls12377.NewMiMC()
+	hasher.Write(b)
+	return hasher.Sum(nil)
 }
 
-
-//export computeMimc
-func computeMimc(input *C.char, inputLength C.int, output *C.char) C.int {
-       inputSlice := C.GoBytes(unsafe.Pointer(input), inputLength)
-       outputSlice := (*[32]byte)(unsafe.Pointer(output))[:]
-       hash := MiMCHash(inputSlice)
-       copy(outputSlice, hash)
-       return C.int(len(hash))
+func MiMCBn254Hash(b []byte) []byte {
+	hasher := mimcBn254.NewMiMC()
+	hasher.Write(b)
+	return hasher.Sum(nil)
 }
 
+//export computeMimcBn254
+func computeMimcBn254(input *C.char, inputLength C.int, output *C.char) C.int {
+	inputSlice := C.GoBytes(unsafe.Pointer(input), inputLength)
+	outputSlice := (*[32]byte)(unsafe.Pointer(output))[:]
+	hash := MiMCBn254Hash(inputSlice)
+	copy(outputSlice, hash)
+	return C.int(len(hash))
+}
+
+//export computeMimcBls12377
+func computeMimcBls12377(input *C.char, inputLength C.int, output *C.char) C.int {
+	inputSlice := C.GoBytes(unsafe.Pointer(input), inputLength)
+	outputSlice := (*[32]byte)(unsafe.Pointer(output))[:]
+	hash := MiMCBls12377Hash(inputSlice)
+	copy(outputSlice, hash)
+	return C.int(len(hash))
+}
 
 func main() {}

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
@@ -37,7 +37,10 @@ public class LibGnark {
         ENABLED = enabled;
     }
 
-    public static native int computeMimc(
+    public static native int computeMimcBn254(
             byte[] i, int i_len, byte[] o);
+
+    public static native int computeMimcBls12377(
+        byte[] i, int i_len, byte[] o);
 
 }

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/LibGnarkTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/LibGnarkTest.java
@@ -25,27 +25,54 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class LibGnarkTest {
 
     @Test
-    public void testHashZero() {
+    public void testHashZeroBn254() {
         byte[] output = new byte[Bytes32.SIZE];
-        LibGnark.computeMimc(Bytes32.ZERO.toArrayUnsafe(), Bytes32.SIZE, output);
+        LibGnark.computeMimcBn254(Bytes32.ZERO.toArrayUnsafe(), Bytes32.SIZE, output);
         assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x2c7298fd87d3039ffea208538f6b297b60b373a63792b4cd0654fdc88fd0d6ee"));
     }
 
     @Test
-    public void testHashOne() {
+    public void testHashOneBn254() {
         byte[] output = new byte[Bytes32.SIZE];
-        LibGnark.computeMimc(Bytes32.leftPad(Bytes.of(1)).toArrayUnsafe(), Bytes32.SIZE, output);
+        LibGnark.computeMimcBn254(Bytes32.leftPad(Bytes.of(1)).toArrayUnsafe(), Bytes32.SIZE, output);
         assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x27e5458b666ef581475a9acddbc3524ca252185cae3936506e65cda9c358222b"));
     }
 
     @Test
-    public void testLongString() {
+    public void testLongStringBn254() {
         MutableBytes input = MutableBytes.of(new byte[Bytes32.SIZE*16]);
         for (int i = 0; i < 16; i++) {
             input.set(Bytes32.SIZE*(i+1)-1,(byte) i);
         }
         byte[] output = new byte[Bytes32.SIZE];
-        LibGnark.computeMimc(input.toArrayUnsafe(), input.size(), output);
+        LibGnark.computeMimcBn254(input.toArrayUnsafe(), input.size(), output);
         assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x145875dd085ea2fb9796333e55c9da80228eb321df0ca9a41ca64ba6fe90b167"));
     }
+
+    @Test
+    public void testHashZeroBls12377() {
+        byte[] output = new byte[Bytes32.SIZE];
+        LibGnark.computeMimcBls12377(Bytes32.ZERO.toArrayUnsafe(), Bytes32.SIZE, output);
+        assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x0134373b65f439c874734ff51ea349327c140cde2e47a933146e6f9f2ad8eb17"));
+    }
+
+    @Test
+    public void testHashOneBls12377() {
+        byte[] output = new byte[Bytes32.SIZE];
+        LibGnark.computeMimcBls12377(Bytes32.leftPad(Bytes.of(1)).toArrayUnsafe(), Bytes32.SIZE, output);
+        assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x0d962bab9f4e4213383f25abc12d6ee78855fff118c94ca4352032b802ef8b87"));
+    }
+
+    @Test
+    public void testLongStringBls12377() {
+        MutableBytes input = MutableBytes.of(new byte[Bytes32.SIZE*16]);
+        for (int i = 0; i < 16; i++) {
+            input.set(Bytes32.SIZE*(i+1)-1,(byte) i);
+        }
+        byte[] output = new byte[Bytes32.SIZE];
+        LibGnark.computeMimcBls12377(input.toArrayUnsafe(), input.size(), output);
+        assertThat(Bytes.wrap(output)).isEqualTo(Bytes.fromHexString("0x12900ae41a010e54e3b1ed95efa39071d357ff642aeedd30a2c4e13250409662"));
+    }
+
+
 }


### PR DESCRIPTION
# Description

The current PR adds supports for the MiMC hash function, but on the BLS12-377 scalar's field (not to be confused with BLS12-381). The implementation is - as for its BN254 counterpart - imported from gnark's. The PR keeps support for the BN254's implementation which is used by Shomei as of now. The implementation 

In more details:

- Renames `computeMiMC` to `computeMiMC254` to make the naming more specific. This can be reverted if deemed useful during the review as this introduces a breaking change.
- Extends the LibGnark class to also provide `computeMiMCBls12377`
- Adds test-cases on the Java side to check the hashes are consistent with what we get on go. The test-vectors used for the testing are the same as the one used for the Bn254 counterpart.