### PR TITLE
fix: fix the commit for verkle dependency

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -22,8 +22,8 @@ repository = "https://github.com/hyperledger/besu-native"
 edition = "2018"
 
 [dependencies]
-verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", branch = "master" }
-verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", branch = "master" }
+verkle-spec = { git = "https://github.com/crate-crypto/rust-verkle", rev = "67d47d9e78f873da7c9e72687158468041059b5d" }
+verkle-trie = { git = "https://github.com/crate-crypto/rust-verkle", rev = "67d47d9e78f873da7c9e72687158468041059b5d" }
 ipa-multipoint = { git = "https://github.com/crate-crypto/ipa_multipoint", branch = "banderwagon_migration" }
 banderwagon = { git = "https://github.com/crate-crypto/banderwagon" }
 bandersnatch = "0.1.1"
@@ -31,7 +31,9 @@ ark-ff = { version = "^0.3.0", default-features = false }
 ark-ec = { version = "^0.3.0", default-features = false }
 ark-serialize = { version = "^0.3.0", default-features = false }
 ark-std = { version = "^0.3.0", default-features = false }
-jni = { version = "0.19.0", features = ["invocation"] } # We use invocation in tests.
+jni = { version = "0.19.0", features = [
+    "invocation",
+] } # We use invocation in tests.
 hex = "0.4.3"
 num-bigint = "0.4.4"
 


### PR DESCRIPTION
This fixes the commit for verkle-trie, since pointing to master can make compiles non-deterministic.

This will change soon to using ffi_interface, though while that PR is not merged this is a fix.