### PR TITLE
add groupToField and return uncompressed serialized commitments

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -22,7 +22,7 @@ use once_cell::sync::Lazy;
 
 // TODO: Use a pointer here instead. This is only being used so that the interface does not get changed.
 // TODO: and bindings do not need to be modified.
-pub static CONFIG: Lazy<ffi_interface::Context> = Lazy::new(|| ffi_interface::Context::default());
+pub static CONFIG: Lazy<ffi_interface::Context> = Lazy::new(ffi_interface::Context::default);
 
 /// Pedersen hash receives an address and a trie index and returns a hash calculated this way:
 /// H(constant || address_low || address_high || trie_index_low || trie_index_high)
@@ -86,9 +86,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 
     let commitment = ffi_interface::commit_to_scalars(committer, &input).unwrap();
 
-    let hash = ffi_interface::hash_commitment(commitment);
-
-    env.byte_array_from_slice(&hash)
+    env.byte_array_from_slice(&commitment)
         .expect("Couldn't convert to byte array")
 }
 
@@ -108,6 +106,24 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 
     let commitment = ffi_interface::commit_to_scalars(committer, &input).unwrap();
     let hash = ffi_interface::deprecated_serialize_commitment(commitment);
+
+    env.byte_array_from_slice(&hash)
+        .expect("Couldn't convert to byte array")
+}
+
+#[no_mangle]
+pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_groupToField(
+    env: JNIEnv,
+    _class: JClass<'_>,
+    input: jbyteArray,
+) -> jbyteArray {
+    let commitment = env
+        .convert_byte_array(input)
+        .expect("Cannot convert jbyteArray to rust array");
+
+    let commitment_bytes = commitment.try_into().unwrap();
+
+    let hash = ffi_interface::hash_commitment(commitment_bytes);
 
     env.byte_array_from_slice(&hash)
         .expect("Couldn't convert to byte array")

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -47,16 +47,23 @@ public class LibIpaMultipoint {
    * Evaluates a polynomial of degree 255 (uniquely defined by 256 values) at a specific point on the curve.
 
    * @param input [Fr,Fr,Fr...]
-   * @return group_to_field(commitment)
+   * @return commitment.to_bytes() - uncompressed serialization
    */
   public static native byte[] commit(byte[] input);
 
   /**
    * Evaluates a polynomial of degree 255 (uniquely defined by 256 values) at a specific point on the curve.
    * @param input [Fr,Fr,Fr...]
-   * @return commitment.to_bytes()
+   * @return commitment.to_bytes() - compressed serialization
    */
   public static native byte[] commitRoot(byte[] input);
+
+  /**
+   * Serializaes group element to field.
+   * @param input C uncompressed serialization = 64bytes
+   * @return Fr = 32 bytes
+   */
+  public static native byte[] groupToField(byte[] input);
 
   /**
    * Pedersen hash as specified in https://notes.ethereum.org/@vbuterin/verkle_tree_eip

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
@@ -27,8 +27,8 @@ public class LibIpaMultipointTest {
     @Test
     public void testCallLibrary() {
         Bytes32 input = Bytes32.fromHexString("0x0000fe0c00000000000000000000000000000000000000000000000000000000");
-        Bytes32 result = Bytes32.wrap(LibIpaMultipoint.commit(input.toArray()));
-        Bytes32 expected = Bytes32.fromHexString("0x11169fb6b9dab0b5984ce0b02c9f2c9a3a5adf6f9a95b597bca42ac2a8d8e89f");
+        Bytes result = Bytes.wrap(LibIpaMultipoint.commit(input.toArray()));
+        Bytes expected = Bytes.fromHexString("0x0c7f8df856f6860c9f2c6cb0f86c10228e511cca1c4a08263189d629940cb189706cbaa63c436901b6355e10a524337d97688fa5b0cf6b2b91b98e654547f728");
         assertThat(result).isEqualTo(expected.reverse());
     }
 
@@ -48,8 +48,8 @@ public class LibIpaMultipointTest {
             arr[i] = element;
         }
         Bytes input = Bytes.concatenate(arr);
-        Bytes32 result = Bytes32.wrap(LibIpaMultipoint.commit(input.toArray()));
-        Bytes32 expected = Bytes32.fromHexString("0x26fa8d679863c1d1a3e66d8653b28be718961f521b22d9589a3f32258c1c8a1b");
+        Bytes result = Bytes.wrap(LibIpaMultipoint.commit(input.toArray()));
+        Bytes expected = Bytes.fromHexString("0x0128b513cfb016d3d836b5fa4a8a1260395d4ca831d65027aa74b832d92e0d6d9beb8d5e42b78b99e4eb233e7eca6276c6f4bd235b35c091546e2a2119bc1455");
         assertThat(result).isEqualTo(expected);
     }
 
@@ -61,8 +61,8 @@ public class LibIpaMultipointTest {
             arr[i] = element;
         }
         Bytes input = Bytes.concatenate(arr);
-        Bytes32 result = Bytes32.wrap(LibIpaMultipoint.commit(input.toArray()));
-        Bytes32 expected = Bytes32.fromHexString("0x43d0f14a66ab88f418cd17e688402fbc2658b8b2211fe7951c584230c5ad8b14");
+        Bytes result = Bytes.wrap(LibIpaMultipoint.commit(input.toArray()));
+        Bytes expected = Bytes.fromHexString("0xcfb8d6fe536dec3d72ae549a0b58c7d2d119e7dd58adb2663369275307cd5a1f8adafed4044dbdc9ba9fb4f7ea0e44ab14c1c47297633015d175d7dcaffeb843");
         assertThat(result).isEqualTo(expected);
     }
 

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/PedersenCommitmentTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/PedersenCommitmentTest.java
@@ -41,7 +41,7 @@ public class PedersenCommitmentTest {
             FrBytes.add(Bytes32.leftPad(Bytes.wrap(decimalBigInt.toByteArray())).reverse());
         }
         byte[] input = Bytes.concatenate(FrBytes).toArray();
-        BigInteger result = Bytes32.wrap(LibIpaMultipoint.commit(input)).toBigInteger(ByteOrder.LITTLE_ENDIAN);
+        BigInteger result = Bytes32.wrap(LibIpaMultipoint.groupToField(LibIpaMultipoint.commit(input))).toBigInteger(ByteOrder.LITTLE_ENDIAN);
         BigInteger expected = new BigInteger(testData.commitment);
         assertThat(result).isEqualTo(expected);
     }


### PR DESCRIPTION
Switching to uncompressed commitments and adding a groupToField method.

Closes https://github.com/hyperledger/besu-native/issues/130 
Closes https://github.com/hyperledger/besu-native/issues/128

This is paired with https://github.com/hyperledger/besu-verkle-trie/pull/37