### PR TITLE
chore!: Modify functionality of `commitRoot` to use `groupToField`

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/hyperledger/besu-native"
 edition = "2018"
 
 [dependencies]
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "bb5af2f2fe9788d49d2896b9614a3125f8227818" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "737020069832c126bcae163a4e788f6879dfd6a6" }
 jni = { version = "0.19.0", features = [
     "invocation",
 ] } # We use invocation in tests.

--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -41,8 +41,6 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
 ) -> jbyteArray {
     let input = env.convert_byte_array(input).unwrap();
 
-    let committer = &CONFIG.committer;
-
     let mut input: [u8; 64] = match input.try_into() {
         Ok(input) => input,
         Err(_) => {
@@ -65,7 +63,7 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
     }
     reverse_last_32_bytes(&mut input);
 
-    let hash = ffi_interface::get_tree_key_hash_flat_input(committer, input);
+    let hash = ffi_interface::get_tree_key_hash_flat_input(&CONFIG, input);
     env.byte_array_from_slice(&hash).unwrap()
 }
 
@@ -82,16 +80,20 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
         .convert_byte_array(input)
         .expect("Cannot convert jbyteArray to rust array");
 
-    let committer = &CONFIG.committer;
-
-    let commitment = ffi_interface::commit_to_scalars(committer, &input).unwrap();
+    let commitment = ffi_interface::commit_to_scalars(&CONFIG, &input).unwrap();
 
     env.byte_array_from_slice(&commitment)
         .expect("Couldn't convert to byte array")
 }
 
-/// Commit_root receives a list of 32 byte scalars and returns a 32 byte commitment.to_bytes()
-/// This is ported from rust-verkle.
+/// Commit_root receives a list of 32 byte scalars and returns a 32 byte array
+///
+/// The 32 bytes represents groupToField(commitment).to_bytes()
+///
+/// TODO: We can remove this method as its the same as calling commit and then groupToField
+/// TODO: This has not been done because it is a breaking API change, that changes the bindings.
+/// TODO: Once downstream besu-verkle switches to using commit and then groupToField, making this
+/// TODO: method unused, then we can remove it.
 #[no_mangle]
 pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaMultipoint_commitRoot(
     env: JNIEnv,
@@ -102,10 +104,8 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
         .convert_byte_array(input)
         .expect("Cannot convert jbyteArray to rust array");
 
-    let committer = &CONFIG.committer;
-
-    let commitment = ffi_interface::commit_to_scalars(committer, &input).unwrap();
-    let hash = ffi_interface::deprecated_serialize_commitment(commitment);
+    let commitment = ffi_interface::commit_to_scalars(&CONFIG, &input).unwrap();
+    let hash = ffi_interface::hash_commitment(commitment);
 
     env.byte_array_from_slice(&hash)
         .expect("Couldn't convert to byte array")
@@ -145,10 +145,27 @@ pub extern "system" fn Java_org_hyperledger_besu_nativelib_ipamultipoint_LibIpaM
         .convert_byte_array(input)
         .expect("Cannot convert jbyteArray to rust array");
 
-    let committer = &CONFIG.committer;
+    let (old_commitment_bytes, indexes, old_scalars, new_scalars) =
+        match ffi_interface::deserialize_update_commitment_sparse(input) {
+            Ok(decomposed_input) => decomposed_input,
+            Err(err) => {
+                env.throw_new(
+                    "java/text/ParseException",
+                    format!("Could not deserialize the input, error : {:?}", err),
+                )
+                .expect("Failed to throw exception");
+                return std::ptr::null_mut(); // Return null pointer to indicate an error
+            }
+        };
 
-    let (old_commitment_bytes,indexes,old_scalars,new_scalars) = ffi_interface::deserialize_update_commitment_sparse(input);
-    let updated_commitment = ffi_interface::update_commitment_sparse(committer, old_commitment_bytes, indexes, old_scalars, new_scalars).unwrap();
+    let updated_commitment = ffi_interface::update_commitment_sparse(
+        &CONFIG,
+        old_commitment_bytes,
+        indexes,
+        old_scalars,
+        new_scalars,
+    )
+    .unwrap();
 
     env.byte_array_from_slice(&updated_commitment)
         .expect("Couldn't convert to byte array")


### PR DESCRIPTION
## Rationale

For the Java library, this will eventually reduce the API surface needed. `commitRoot` will essentially become a call to `commitToScalar` + `groupToField`.

This issue expands on the rationale: https://github.com/crate-crypto/rust-verkle/issues/86

---

There are some geth and go-verkle PRs which would be good to merge before merging this (Leaving this as a Draft while those are open)