### PR TITLE
chore!: Updates rust-verkle dependency

### DIFF
--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/hyperledger/besu-native"
 edition = "2018"
 
 [dependencies]
-ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "bb5af2f2fe9788d49d2896b9614a3125f8227818" }
+ffi_interface = { git = "https://github.com/crate-crypto/rust-verkle", rev = "7688f0aedfb147d3d391abfe8495e46c46d72ce0" }
 jni = { version = "0.19.0", features = [
     "invocation",
 ] } # We use invocation in tests.

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
@@ -73,7 +73,7 @@ public class LibIpaMultipointTest {
         Bytes32 trieIndex = Bytes32.fromHexString("0x004C6CE0115457AC1AB82968749EB86ED2D984743D609647AE88299989F91271");
         byte[] total = Bytes.wrap(address, trieIndex).toArray();
         Bytes result = Bytes.of(LibIpaMultipoint.pedersenHash(total));
-        assertThat(result).isEqualTo(Bytes32.fromHexString("0xff6e8f1877fd27f91772a4cec41d99d2f835d7320e929b8d509c5fa7ce095c51"));
+        assertThat(result).isEqualTo(Bytes32.fromHexString("eeda254375eea77b9f8904610c79ecbe039c2a63b064c453fd8910f7055ced10"));
     }
 
     @Test


### PR DESCRIPTION
updates the rust verkle dependency to the latest version and modifies the code to match.

- PedersenHash has changed internally to use MapToScalarField
- Methods now take a context and not a committer to make calling them easier.