### PR TITLE
chore!: Removes pedersenHash method

### DIFF
--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -66,13 +66,6 @@ public class LibIpaMultipoint {
   public static native byte[] groupToField(byte[] input);
 
   /**
-   * Pedersen hash as specified in https://notes.ethereum.org/@vbuterin/verkle_tree_eip
-   * @param input Expects 64byte value as input encoded as byte[]
-   * @return 32bytes as byte[]
-   */
-  public static native byte[] pedersenHash(byte[] input);
-
-  /**
    * Update Commitment sparse
    * @param input Expects byteArray of fixed 64bytes for the commitment
    * and dynamic tuple (old_scalar(32 bytes), new_scalar(32 bytes), index(1 byte)) in this sequence

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
@@ -67,16 +67,6 @@ public class LibIpaMultipointTest {
     }
 
     @Test
-    public void testCallLibraryPedersenHash() {
-        // Example of passing address and trieIndex to pedersenHash.
-        Bytes32 address = Bytes32.fromHexString("0x003f9549040250ec5cdef31947e5213edee80ad2d5bba35c9e48246c5d9213d6");
-        Bytes32 trieIndex = Bytes32.fromHexString("0x004C6CE0115457AC1AB82968749EB86ED2D984743D609647AE88299989F91271");
-        byte[] total = Bytes.wrap(address, trieIndex).toArray();
-        Bytes result = Bytes.of(LibIpaMultipoint.pedersenHash(total));
-        assertThat(result).isEqualTo(Bytes32.fromHexString("eeda254375eea77b9f8904610c79ecbe039c2a63b064c453fd8910f7055ced10"));
-    }
-
-    @Test
     public void testUpdateCommitmentSparseIdentityCommitment() {
         // Numbers and result is taken from: https://github.com/crate-crypto/rust-verkle/blob/bb5af2f2fe9788d49d2896b9614a3125f8227818/ffi_interface/src/lib.rs#L576
         // Identity element


### PR DESCRIPTION
Once https://github.com/hyperledger/besu-verkle-trie/pull/43 is merged, the `pedersenHash` method will no longer be needed.

This PR removes it from the API.