### PR TITLE
gradle upgrade errata: fix implied deps error 

### DIFF
--- a/altbn128/build.gradle
+++ b/altbn128/build.gradle
@@ -27,25 +27,25 @@ task macArmLibCopy(type: Copy) {
   from 'build/darwin-aarch64/lib/libeth_altbn128.dylib'
   into 'build/resources/main/darwin-aarch64'
 }
-jar.dependsOn macArmLibCopy
+processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
   from 'build/darwin-x86-64/lib/libeth_altbn128.dylib'
   into 'build/resources/main/darwin-x86-64'
 }
-jar.dependsOn macLibCopy
+processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
   from 'build/linux-gnu-x86_64/lib/libeth_altbn128.so'
   into 'build/resources/main/linux-x86-64'
 }
-jar.dependsOn linuxLibCopy
+processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
   from 'build/linux-gnu-aarch64/lib/libeth_altbn128.so'
   into 'build/resources/main/linux-aarch64'
 }
-jar.dependsOn linuxArm64LibCopy
+processResources.dependsOn linuxArm64LibCopy
 
 jar {
   archiveBaseName = 'besu-native-altbn128'

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -27,25 +27,25 @@ task macArmLibCopy(type: Copy) {
   from 'build/darwin-aarch64/lib/libsecp256k1.dylib'
   into 'build/resources/main/darwin-aarch64'
 }
-jar.dependsOn macArmLibCopy
+processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
   from 'build/darwin-x86-64/lib/libsecp256k1.dylib'
   into 'build/resources/main/darwin-x86-64'
 }
-jar.dependsOn macLibCopy
+processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
   from 'build/linux-gnu-x86_64/lib/libsecp256k1.so'
   into 'build/resources/main/linux-x86-64'
 }
-jar.dependsOn linuxLibCopy
+processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
   from 'build/linux-gnu-aarch64/lib/libsecp256k1.so'
   into 'build/resources/main/linux-aarch64'
 }
-jar.dependsOn linuxArm64LibCopy
+processResources.dependsOn linuxArm64LibCopy
 
 jar {
   archiveBaseName = 'besu-native-secp256k1'

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -41,28 +41,28 @@ task macArmLibCopy(type: Copy) {
     from 'besu-native-ec/release/darwin-aarch64/libbesu_native_ec_crypto.dylib'
     into 'build/resources/main/darwin-aarch64'
 }
-jar.dependsOn macArmLibCopy
+processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
     from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec.dylib'
     from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec_crypto.dylib'
     into 'build/resources/main/darwin-x86-64'
 }
-jar.dependsOn macLibCopy
+processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
     from 'besu-native-ec/release/linux-gnu-x86_64/libbesu_native_ec.so'
     from 'besu-native-ec/release/linux-gnu-x86_64/libbesu_native_ec_crypto.so'
     into 'build/resources/main/linux-x86-64'
 }
-jar.dependsOn linuxLibCopy
+processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
     from 'besu-native-ec/release/linux-gnu-aarch64/libbesu_native_ec.so'
     from 'besu-native-ec/release/linux-gnu-aarch64/libbesu_native_ec_crypto.so'
     into 'build/resources/main/linux-aarch64'
 }
-jar.dependsOn linuxArm64LibCopy
+processResources.dependsOn linuxArm64LibCopy
 
 jar {
     archiveBaseName = 'besu-native-secp256r1'


### PR DESCRIPTION
Undiscovered fallout from the upgrade to gradle 8.8 resulted in a failure of the publish task (which isn't executed in the CI pipeline normally)

this PR fixes the dep issue for a few gradle projects 