### PR TITLE
0.9.0 errata, move to tmio for tuweni dep

### DIFF
--- a/arithmetic/build.gradle
+++ b/arithmetic/build.gradle
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'com.google.guava:guava:31.1-jre'
-    testImplementation 'org.apache.tuweni:tuweni-bytes:2.2.0'
+    testImplementation 'io.tmio:tuweni-bytes:2.4.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'

--- a/bls12-381/build.gradle
+++ b/bls12-381/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -23,7 +23,7 @@ dependencies {
   implementation 'net.java.dev.jna:jna:5.12.1'
   testImplementation 'com.google.guava:guava:31.1-jre'
   testImplementation 'junit:junit:4.13.2'
-  testImplementation 'org.apache.tuweni:tuweni-bytes:2.2.0'
+  testImplementation 'io.tmio:tuweni-bytes:2.4.2'
   testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -21,6 +21,7 @@ plugins {
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.12.1'
+    testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
     testImplementation 'junit:junit:4.13.2'

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -22,7 +22,7 @@ plugins {
 dependencies {
     implementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'net.java.dev.jna:jna:5.12.1'
-    implementation 'org.apache.tuweni:tuweni-bytes:2.2.0'
+    testImplementation 'io.tmio:tuweni-bytes:2.4.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.mockito:mockito-core:4.4.0'

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
@@ -68,16 +68,6 @@ public class LibGnarkEIP196 {
     return ret;
   }
 
-  public int findFirstTrailingZeroIndex(byte[] array) {
-    for (int i = array.length - 1; i >= 0; i--) {
-      if (array[i] != 0) {
-        return i + 1; // The first trailing zero is after this non-zero byte
-      }
-    }
-    // If all bytes are zero, return 0
-    return 0;
-  }
-
   public static native int eip196altbn128G1Add(
       byte[] input,
       byte[] output,

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
@@ -2,7 +2,6 @@ package org.hyperledger.besu.nativelib.gnark;
 
 import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
-import org.apache.tuweni.bytes.Bytes;
 
 public class LibGnarkEIP196 {
 
@@ -61,8 +60,7 @@ public class LibGnarkEIP196 {
     }
 
     if (ret != 0) {
-      var errBytes = Bytes.wrap(err);
-      err_len.setValue(errBytes.size() - errBytes.numberOfTrailingZeroBytes());
+      err_len.setValue(LibGnarkUtils.findFirstTrailingZeroIndex(err));
       o_len.setValue(0);
     } else {
       err_len.setValue(0);
@@ -70,6 +68,15 @@ public class LibGnarkEIP196 {
     return ret;
   }
 
+  public int findFirstTrailingZeroIndex(byte[] array) {
+    for (int i = array.length - 1; i >= 0; i--) {
+      if (array[i] != 0) {
+        return i + 1; // The first trailing zero is after this non-zero byte
+      }
+    }
+    // If all bytes are zero, return 0
+    return 0;
+  }
 
   public static native int eip196altbn128G1Add(
       byte[] input,

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
@@ -3,9 +3,6 @@ package org.hyperledger.besu.nativelib.gnark;
 import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
-import org.apache.tuweni.bytes.Bytes;
-
-import java.nio.charset.StandardCharsets;
 
 public class LibGnarkEIP2537 implements Library {
 
@@ -110,8 +107,7 @@ public class LibGnarkEIP2537 implements Library {
     }
 
     if (ret != 0) {
-      var errBytes = Bytes.wrap(err);
-      err_len.setValue(errBytes.size() - errBytes.numberOfTrailingZeroBytes());
+      err_len.setValue(LibGnarkUtils.findFirstTrailingZeroIndex(err));
       o_len.setValue(0);
     } else {
       err_len.setValue(0);

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkUtils.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkUtils.java
@@ -1,0 +1,14 @@
+package org.hyperledger.besu.nativelib.gnark;
+
+public class LibGnarkUtils {
+
+  public static int findFirstTrailingZeroIndex(byte[] array) {
+    for (int i = array.length - 1; i >= 0; i--) {
+      if (array[i] != 0) {
+        return i + 1; // The first trailing zero is after this non-zero byte
+      }
+    }
+    // If all bytes are zero, return 0
+    return 0;
+  }
+}

--- a/ipa-multipoint/build.gradle
+++ b/ipa-multipoint/build.gradle
@@ -21,7 +21,7 @@ plugins {
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.12.1'
-    testImplementation 'org.apache.tuweni:tuweni-bytes:2.3.1'
+  testImplementation 'io.tmio:tuweni-bytes:2.4.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright Hyperledger Besu contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.apache.tuweni:tuweni-bytes:2.2.0'
+    testImplementation 'io.tmio:tuweni-bytes:2.4.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 


### PR DESCRIPTION
Remove tuweni as a runtime dependency for gnark-crypto, back to testImplementation dependency.  Also, bump tuweni dep to tmio.

In besu we have to specifically exclude this dependency from the gnark dep to prevent conflicts with besu's version of tuweni.