### PR TITLE
release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-# 0.9.2-SNAPSHOT
+# 0.9.2
+* Additional malformed input handling for EIP-196 [#188](https://github.com/hyperledger/besu-native/pull/188)
 
 # 0.9.1
 * remove tuweni-bytes dependency from gnark-crypto artifcat [#182](https://github.com/hyperledger/besu-native/pull/182)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.9.2-SNAPSHOT
+version=0.9.2


### PR DESCRIPTION
minor release addressing malformed inputs for gnark-crypto impl of EIP-196