### PR TITLE
Prevent publishing same version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,14 @@ jobs:
       # Only check binary for arithmetic as all published together and arithmetic is the first
       - name: Check release published
         run: |
-          # Skip if version contain SNAPSHOT
-          grep "^version" gradle.properties | grep -q SNAPSHOT || {
+          # Only interested in release version
+          if [[ $(grep -E 'version=[0-9]+\.[0-9]+\.[0-9]+$' gradle.properties | wc -l) -ne 0 ]]
+          then
             # Extract version from gradle.properties
             VERSION=$(grep "^version" gradle.properties | sed 's|^version=\(.*\)$|\1|g')
             echo "Query for version [$VERSION]"
             RESPONSE_CODE=$(curl --head -L --silent --output /dev/null  --write-out %{http_code} "$ART_URL/$VERSION")
-            echo "DEBUG: Response code from curl command [$RESPONSE_CODE]"
+            echo "Response code for curl command [$RESPONSE_CODE]"
             if [[ $RESPONSE_CODE == "404" ]]
             then
               echo "Version [$VERSION] has not yet been published"
@@ -63,8 +64,11 @@ jobs:
                 echo "WARN: Failing job due to unknown status"
                 exit 1
               fi
+
             fi
-          }
+          else
+            echo "No validation as not a release version"
+          fi
         env:
           ART_URL: 'https://hyperledger.jfrog.io/artifactory/besu-maven/org/hyperledger/besu/arithmetic'
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,37 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      # Check whether gradle.properties version has been released already
+      # This prevents accidently publish same version
+      # Only check binary for arithmetic as all published together and arithmetic is the first
+      - name: Check release published
+        run: |
+          # Skip if version contain SNAPSHOT
+          grep "^version" gradle.properties | grep -q SNAPSHOT || {
+            # Extract version from gradle.properties
+            VERSION=$(grep "^version" gradle.properties | sed 's|^version=\(.*\)$|\1|g')
+            echo "Query for version [$VERSION]"
+            RESPONSE_CODE=$(curl --head -L --silent --output /dev/null  --write-out %{http_code} "$ART_URL/$VERSION")
+            echo "DEBUG: Response code from curl command [$RESPONSE_CODE]"
+            if [[ $RESPONSE_CODE == "404" ]]
+            then
+              echo "Version [$VERSION] has not yet been published"
+            else
+              if [[ $RESPONSE_CODE == "200" ]]
+              then
+                echo "ERROR: Binary arithmetic already exists for version [$VERSION]"
+                echo "ERROR: Blocking republishing same version to the Besu Artifactory"
+                echo "url $ART_URL/$VERSION"
+                exit 1
+              else
+                echo "WARN: Unable to check whether version has been published previously"
+                echo "WARN: Failing job due to unknown status"
+                exit 1
+              fi
+            fi
+          }
+        env:
+          ART_URL: 'https://hyperledger.jfrog.io/artifactory/besu-maven/org/hyperledger/besu/arithmetic'
       - name: Build
         run: ./build.sh
       - uses: actions/upload-artifact@v3.1.0


### PR DESCRIPTION
Workflow checks whether the configured non snapshot version has been published already to prevent re-publish same version