### PR TITLE
Update runner version to ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   native-build-linux-x86-64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       SKIP_GRADLE: true
     steps:


### PR DESCRIPTION
Build job fails with error `version GLIBC_2.34 not found`. Update the runner version to ubuntu-22.04