### PR TITLE
Optimizations in bn254 ECMUL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ Cargo.lock
 *.a
 *.dylib
 constantine/out
+gnark/gnark-jni/*.h
+

--- a/gnark/gnark-jni/gnark-eip-196.go
+++ b/gnark/gnark-jni/gnark-eip-196.go
@@ -127,8 +127,9 @@ func eip196altbn128G1Mul(javaInputBuf, javaOutputBuf, javaErrorBuf *C.char, cInp
     // Convert input C pointers to Go slice
     input := (*[EIP196PreallocateForG1 + EIP196PreallocateForScalar]byte)(unsafe.Pointer(javaInputBuf))[:inputLen:inputLen]
 
-    // inifinity check:
+    // infinity check:
     if isAllZeroEIP196(input, 0, 64) {
+        *outputLen = EIP196PreallocateForG1
         return 0
     }
 


### PR DESCRIPTION
Optimizations for ecmul in gnark-crypto eip196 imple for ECMUL:

* use .Double() when ecmul when scalar == 2 
* if point is infinity encoding, just return infinity 