### PR TITLE
Use improved subgroup checks from gnark-crypto

### DIFF
--- a/gnark/gnark-jni/go.mod
+++ b/gnark/gnark-jni/go.mod
@@ -4,11 +4,11 @@ go 1.22
 
 toolchain go1.22.4
 
-require github.com/consensys/gnark-crypto v0.14.0
+require github.com/consensys/gnark-crypto v0.14.1-0.20241028195830-37b2cbd0023e
 
 require (
 	github.com/bits-and-blooms/bitset v1.14.2 // indirect
-	github.com/consensys/bavard v0.1.13 // indirect
+	github.com/consensys/bavard v0.1.22 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect

--- a/gnark/gnark-jni/go.sum
+++ b/gnark/gnark-jni/go.sum
@@ -2,8 +2,12 @@ github.com/bits-and-blooms/bitset v1.14.2 h1:YXVoyPndbdvcEVcseEovVfp0qjJp7S+i5+x
 github.com/bits-and-blooms/bitset v1.14.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
+github.com/consensys/bavard v0.1.22 h1:Uw2CGvbXSZWhqK59X0VG/zOjpTFuOMcPLStrp1ihI0A=
+github.com/consensys/bavard v0.1.22/go.mod h1:k/zVjHHC4B+PQy1Pg7fgvG3ALicQw540Crag8qx+dZs=
 github.com/consensys/gnark-crypto v0.14.0 h1:DDBdl4HaBtdQsq/wfMwJvZNE80sHidrK3Nfrefatm0E=
 github.com/consensys/gnark-crypto v0.14.0/go.mod h1:CU4UijNPsHawiVGNxe9co07FkzCeWHHrb1li/n1XoU0=
+github.com/consensys/gnark-crypto v0.14.1-0.20241028195830-37b2cbd0023e h1:8pOwq+p/tyWdQJNbik+/tV5AnEdswty59QmfEF0mbV0=
+github.com/consensys/gnark-crypto v0.14.1-0.20241028195830-37b2cbd0023e/go.mod h1:F/hJyWBcTr1sWeifAKfEN3aVb3G4U5zheEC8IbWQun4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=


### PR DESCRIPTION
Use [subgroup performance improvement](https://github.com/Consensys/gnark-crypto/pull/557) in gnark-crypto main.

All of the besu performance and correctness tests for BLS12 have been using this commit since late October.  This PR aims to git it into main ahead of pectra devnet-5, which will have updated bls spec implementation