### PR TITLE
Ensure output length is set for low pair count MSM

### DIFF
--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
@@ -72,8 +72,8 @@ public class LibGnarkEIP2537 implements Library {
           ret = eip2537blsG1MultiExpParallel(i, output, err, i_len,
               EIP2537_PREALLOCATE_FOR_RESULT_BYTES, EIP2537_PREALLOCATE_FOR_ERROR_BYTES,
               degreeOfMSMParallelism);
-          o_len.setValue(128);
         }
+        o_len.setValue(128);
         break;
       case BLS12_G2ADD_OPERATION_SHIM_VALUE:
         ret = eip2537blsG2Add(i, output, err, i_len,
@@ -97,8 +97,8 @@ public class LibGnarkEIP2537 implements Library {
           ret = eip2537blsG2MultiExpParallel(i, output, err, i_len,
               EIP2537_PREALLOCATE_FOR_RESULT_BYTES, EIP2537_PREALLOCATE_FOR_ERROR_BYTES,
               degreeOfMSMParallelism);
-          o_len.setValue(256);
         }
+        o_len.setValue(256);
         break;
       case BLS12_PAIR_OPERATION_SHIM_VALUE:
         ret = eip2537blsPairing(i, output, err, i_len,


### PR DESCRIPTION
bugfix, set the output length for both pippengers and non-pip MSM result. regression from #226 