### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,31 +73,31 @@ jobs:
           ART_URL: 'https://hyperledger.jfrog.io/artifactory/besu-maven/org/hyperledger/besu/arithmetic'
       - name: Build
         run: ./build.sh
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: arithmetic native build artifacts
           path: arithmetic/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: blake2bf native build artifacts
           path: blake2bf/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256k1 native build artifacts
           path: secp256k1/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256r1 native build artifacts
           path: secp256r1/besu-native-ec/release/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: gnark native build artifacts
           path: gnark/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: constantine native build artifacts
           path: constantine/build/
@@ -114,31 +114,31 @@ jobs:
       - name: Build
         run: |
           docker run -e SKIP_GRADLE=$SKIP_GRADLE -v $(pwd):/home/ubuntu ubuntu:20.04 /home/ubuntu/native-build.sh
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: arithmetic native build artifacts
           path: arithmetic/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: blake2bf native build artifacts
           path: blake2bf/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256k1 native build artifacts
           path: secp256k1/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256r1 native build artifacts
           path: secp256r1/besu-native-ec/release/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: gnark native build artifacts
           path: gnark/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: constantine native build artifacts
           path: constantine/build/
@@ -171,31 +171,31 @@ jobs:
           submodules: recursive
       - name: Build
         run: ./build.sh
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: arithmetic native build artifacts
           path: arithmetic/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: blake2bf native build artifacts
           path: blake2bf/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256k1 native build artifacts
           path: secp256k1/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256r1 native build artifacts
           path: secp256r1/besu-native-ec/release/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: gnark native build artifacts
           path: gnark/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: constantine native build artifacts
           path: constantine/build/
@@ -251,31 +251,31 @@ jobs:
           export HOMEBREW_BIN=${{ env.HOMEBREW_BIN }}
           export PATH=$HOMEBREW_BIN:$PATH
           ./build.sh
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: arithmetic native build artifacts
           path: arithmetic/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: blake2bf native build artifacts
           path: blake2bf/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256k1 native build artifacts
           path: secp256k1/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: secp256r1 native build artifacts
           path: secp256r1/besu-native-ec/release/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: gnark native build artifacts
           path: gnark/build/
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: constantine native build artifacts
           path: constantine/build/
@@ -291,37 +291,37 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v4
       - name: Download arithmetic
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: arithmetic native build artifacts
           path: arithmetic/build/
       - name: Download blake2bf
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: blake2bf native build artifacts
           path: blake2bf/build/
       - name: Download secp256k1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: secp256k1 native build artifacts
           path: secp256k1/build/
       - name: Download secp256r1
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: secp256r1 native build artifacts
           path: secp256r1/besu-native-ec/release/
       - name: Download ipa-multipoint
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ipa-multipoint native build artifacts
           path: ipa-multipoint/build/
       - name: Download gnark
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gnark native build artifacts
           path: gnark/build/
       - name: Download constantine
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: constantine native build artifacts
           path: constantine/build/
@@ -335,31 +335,31 @@ jobs:
         uses: gradle/gradle-build-action@v2.4.2
         with:
           arguments: --no-daemon --parallel build --scan
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: arithmetic/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: blake2bf/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: secp256k1/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: secp256r1/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: ipa-multipoint/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: gnark/build/libs
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v4.0.0
         with:
           name: jars
           path: constantine/build/libs


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/