### PR TITLE
revert build to ubuntu 20.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   native-build-linux-x86-64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       SKIP_GRADLE: true
     steps:
@@ -281,7 +281,7 @@ jobs:
           path: constantine/build/
 
   final-assembly:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     needs:
       - native-build-macos
       - native-build-m1


### PR DESCRIPTION
20.04 is still supported until May, and there doesn't seem to be any significant benefit to using the more recent glibc in 22.04.

* reverts to 20.04 for CI build