### PR TITLE
initial pass at adding riscv64 support in besu-native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 # Unreleased
 * bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements
+* add riscv64 support for building besu-native, no CI support yet [#244](https://github.com/hyperledger/besu-native/pull/244)
 
 # 1.1.2
 Ubuntu 20.04 glibc support release

--- a/arithmetic/build.gradle
+++ b/arithmetic/build.gradle
@@ -54,6 +54,12 @@ task linuxArm64LibCopy(type: Copy) {
 }
 processResources.dependsOn linuxArm64LibCopy
 
+task linuxRiscv64LibCopy(type: Copy) {
+    from 'build/linux-gnu-riscv64/lib/libeth_arithmetic.so'
+    into 'build/resources/main/linux-riscv64'
+}
+processResources.dependsOn linuxRiscv64LibCopy
+
 jar {
     archiveBaseName = 'besu-native-arithmetic'
     includeEmptyDirs = false

--- a/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
+++ b/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
@@ -74,6 +74,7 @@ public class LibBlake2bfTest {
   @Test
   public void eip152TestCases() {
     Assume.assumeFalse(System.getProperty("os.arch").equals("aarch64"));
+    Assume.assumeFalse(System.getProperty("os.arch").equals("riscv64"));
     byte[] out = new byte[64];
     messageDigest.blake2bf_eip152(out, input);
     assertThat(out).isEqualTo(expected);

--- a/build.sh
+++ b/build.sh
@@ -66,8 +66,8 @@ build_blake2bf() {
   #############################
 EOF
 
-  # This version of arm blake is actually slower than java blake on arm
-  if [[ "$OSARCH" == "linux-gnu-aarch64" ]];  then
+  # This version of arm blake is actually slower than java blake on arm, probably also on riscv64
+  if [[ "$OSARCH" == "linux-gnu-aarch64" || "$OSARCH" == "linux-gnu-riscv64" ]];  then
     return
     #cd "$SCRIPTDIR/blake2bf/arm64"
   else if [[ "$OSARCH" == "darwin-aarch64" ]];  then
@@ -300,6 +300,12 @@ build_constantine() {
   echo "#############################"
   echo "####### build constantine ####"
   echo "#############################"
+  
+  # don't try to build constantine on riscv64
+  if [[ "$OSARCH" == "linux-gnu-riscv64" ]];  then
+    return
+  fi
+
 
   cd "$SCRIPTDIR/constantine/constantine"
 

--- a/constantine/build.gradle
+++ b/constantine/build.gradle
@@ -51,7 +51,7 @@ processResources.dependsOn macArmLibCopy, macLibCopy, linuxLibCopy, linuxArm64Li
 test {
     // Check if the OS architecture is riscv64
     if (System.getProperty("os.arch").equals("riscv64")) {
-        // Skip tests
+        // Skip for riscv64 since we are not building constantine for riscv64 yet
         enabled = false
     } else {
         // environment 'LD_LIBRARY_PATH', "${System.env.LD_LIBRARY_PATH}:build/resources/main/linux-gnu-x86_64"

--- a/constantine/build.gradle
+++ b/constantine/build.gradle
@@ -49,9 +49,15 @@ task linuxArm64LibCopy(type: Copy) {
 processResources.dependsOn macArmLibCopy, macLibCopy, linuxLibCopy, linuxArm64LibCopy
 
 test {
-//    environment 'LD_LIBRARY_PATH', "${System.env.LD_LIBRARY_PATH}:build/resources/main/linux-gnu-x86_64"
-    systemProperty 'jna.library.path', file('build/resources/main/linux-gnu-x86_64').absolutePath
-    dependsOn macArmLibCopy, macLibCopy, linuxLibCopy, linuxArm64LibCopy
+    // Check if the OS architecture is riscv64
+    if (System.getProperty("os.arch").equals("riscv64")) {
+        // Skip tests
+        enabled = false
+    } else {
+        // environment 'LD_LIBRARY_PATH', "${System.env.LD_LIBRARY_PATH}:build/resources/main/linux-gnu-x86_64"
+        systemProperty 'jna.library.path', file('build/resources/main/linux-gnu-x86_64').absolutePath
+        dependsOn macArmLibCopy, macLibCopy, linuxLibCopy, linuxArm64LibCopy
+    }
 }
 
 jar {

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -61,6 +61,14 @@ task linuxArm64LibCopy(type: Copy) {
 }
 processResources.dependsOn linuxArm64LibCopy
 
+task linuxRiscv64LibCopy(type: Copy) {
+    from 'build/linux-gnu-riscv64/lib/libgnark_jni.so'
+    from 'build/linux-gnu-riscv64/lib/libgnark_eip_2537.so'
+    from 'build/linux-gnu-riscv64/lib/libgnark_eip_196.so'
+    into 'build/resources/main/linux-riscv64'
+}
+processResources.dependsOn linuxRiscv64LibCopy
+
 jar {
     archiveBaseName = 'besu-native-gnark'
     includeEmptyDirs = false

--- a/ipa-multipoint/build.gradle
+++ b/ipa-multipoint/build.gradle
@@ -65,6 +65,12 @@ task linuxArm64LibCopy(type: Copy) {
 }
 processResources.dependsOn linuxArm64LibCopy
 
+task linuxRiscv64LibCopy(type: Copy) {
+  from 'build/linux-gnu-riscv64/lib/libipa_multipoint_jni.so'
+  into 'build/resources/main/linux-riscv64'
+}
+processResources.dependsOn linuxRiscv64LibCopy
+
 jar {
   archiveBaseName = 'besu-native-ipa-multipoint'
   includeEmptyDirs = false

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -47,6 +47,12 @@ task linuxArm64LibCopy(type: Copy) {
 }
 processResources.dependsOn linuxArm64LibCopy
 
+task linuxRiscv64LibCopy(type: Copy) {
+  from 'build/linux-gnu-riscv64/lib/libsecp256k1.so'
+  into 'build/resources/main/linux-riscv64'
+}
+processResources.dependsOn linuxRiscv64LibCopy
+
 jar {
   archiveBaseName = 'besu-native-secp256k1'
   includeEmptyDirs = false

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -64,6 +64,13 @@ task linuxArm64LibCopy(type: Copy) {
 }
 processResources.dependsOn linuxArm64LibCopy
 
+task linuxRiscv64LibCopy(type: Copy) {
+    from 'besu-native-ec/release/linux-gnu-riscv64/libbesu_native_ec.so'
+    from 'besu-native-ec/release/linux-gnu-riscv64/libbesu_native_ec_crypto.so'
+    into 'build/resources/main/linux-riscv64'
+}
+processResources.dependsOn linuxRiscv64LibCopy
+
 jar {
     archiveBaseName = 'besu-native-secp256r1'
     includeEmptyDirs = false

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,6 @@
 rootProject.name='besu-native'
 include 'arithmetic'
 include 'blake2bf'
-include 'bls12-381'
 include 'ipa-multipoint'
 include 'secp256k1'
 include 'secp256r1'


### PR DESCRIPTION
Allow besu-native to build on linux-gnu-riscv64 , ignore constantine and blake2.

This PR just adds the build targets, it does not add CI for riscv64.  The resulting merge will not automatically create a riscv64 compatible besu-native release.

Tested on bpif3 with Armbian

![image](https://github.com/user-attachments/assets/9eb33401-e42f-4654-a9bd-7cd0d9e50d9b)
