### PR TITLE
Refactor of library loading to remove platform/arch naming differences

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           sudo apt autoremove -y
           # golang dependencies
           wget https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
-          echo "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd go1.24.1.linux-amd64.tar.gz" | sha256sum -c || exit 1
+          echo "cb2396bae64183cdccf81a9a6df0aea3bce9511fc21469fb89a0c00470088073 go1.24.1.linux-amd64.tar.gz" | sha256sum -c || exit 1
           tar -xzf go1.24.1.linux-amd64.tar.gz
           export GOROOT=$(pwd)/go
           export PATH=$GOROOT/bin:$PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,9 +20,9 @@ jobs:
           sudo apt-get install -y autoconf build-essential libtool automake patchelf
           sudo apt autoremove -y
           # golang dependencies
-          wget https://go.dev/dl/go1.23.1.linux-amd64.tar.gz
-          echo "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd go1.23.1.linux-amd64.tar.gz" | sha256sum -c || exit 1
-          tar -xzf go1.23.1.linux-amd64.tar.gz
+          wget https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
+          echo "49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd go1.24.1.linux-amd64.tar.gz" | sha256sum -c || exit 1
+          tar -xzf go1.24.1.linux-amd64.tar.gz
           export GOROOT=$(pwd)/go
           export PATH=$GOROOT/bin:$PATH
           # rust dependencies
@@ -154,7 +154,7 @@ jobs:
           # secp256k1 dependencies
           brew install autoconf automake libtool
           # gnark dependencies
-          brew install go@1.23 || true
+          brew install go@1.24 || true
           # rust dependencies
           export CARGO_HOME="$HOME/.cargo"
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.75.0
@@ -221,7 +221,7 @@ jobs:
           # secp256k1, gnark dependencies
           brew install autoconf automake libtool
           # gnark dependencies
-          brew install go@1.23 || true 
+          brew install go@1.24 || true 
           # rust dependencies
           export CARGO_HOME="$HOME/.cargo"
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.75.0
@@ -246,7 +246,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - name: Build
         run: |
           export HOMEBREW_BIN=${{ env.HOMEBREW_BIN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 # Unreleased
-* bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements
+* refactor library loading to conform arch names [#245](https://github.com/hyperledger/besu-native/pull/245)
+* bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements [#240](https://github.com/hyperledger/besu-native/pull/240)
 * add riscv64 support for building besu-native, no CI support yet [#244](https://github.com/hyperledger/besu-native/pull/244)
 
 # 1.1.2

--- a/README.md
+++ b/README.md
@@ -37,8 +37,31 @@ brew install autoconf automake libtool
 TBD
 
 ### Golang
-Golang needs to be installed to compile the gnark-based libraries.  You can fetch the latest golang distribution here:
+
+Golang is required to compile the gnark-based libraries for all platforms and architectures.  
+
+On MacOs, homebrew has a working golang target, e.g.:
+
+`brew install go`
+
+on Linux, for most recent distributions there is typically a somewhat recent go package, e.g.
+`apt install go`
+
+You can fetch the latest golang distribution here:
 https://go.dev/dl/
+
+### Nim
+
+Nim is required to build Constantine.  Constantine is skipped on riscv64 architectures, so it is not needed for linux-riscv64.
+On MacOs, homebrew has a working nim target, e.g.:
+
+`brew install nim`
+
+on Linux, for most recent distributions there is typically a nim package, e.g. 
+`apt install nim`
+
+Otherwise see:
+https://nim-lang.org/install.html
 
 ### Rust
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,13 @@ You'll need to be sure that gcc, make, autoconf, automake, and libtool are insta
 building on Ubuntu or Debian, the following command will install these dependencies for you:
 
 ```
-sudo apt-get install build-essential automake autoconf libtool patchelf
+sudo apt-get install build-essential automake autoconf libtool patchelf nim
 ```
+
+Additionally you will need golang and rust.  Linux distributions do not typicall have the latest 
+versions of these platforms.  Check these for latest builds:
+https://www.rust-lang.org/tools/install
+https://go.dev/dl/
 
 ### OS X
 
@@ -31,9 +36,13 @@ brew install autoconf automake libtool
 
 TBD
 
+### Golang
+Golang needs to be installed to compile the gnark-based libraries.  You can fetch the latest golang distribution here:
+https://go.dev/dl/
+
 ### Rust
 
-Rust needs to be installed to compile the arithmetic and bls12-381 libraries. The default way to install it on Linux or OS X is:
+Rust needs to be installed to compile the arithmetic library. The default way to install it on Linux or OS X is:
 
 ```
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/README.md
+++ b/README.md
@@ -13,13 +13,8 @@ You'll need to be sure that gcc, make, autoconf, automake, and libtool are insta
 building on Ubuntu or Debian, the following command will install these dependencies for you:
 
 ```
-sudo apt-get install build-essential automake autoconf libtool patchelf nim
+sudo apt-get install build-essential automake autoconf libtool patchelf
 ```
-
-Additionally you will need golang and rust.  Linux distributions do not typicall have the latest 
-versions of these platforms.  Check these for latest builds:
-https://www.rust-lang.org/tools/install
-https://go.dev/dl/
 
 ### OS X
 
@@ -35,6 +30,15 @@ brew install autoconf automake libtool
 ### Windows
 
 TBD
+
+
+## Language tools
+
+Additionally you will need golang, rust, and nim.  Distributions often do not have the latest
+versions of these languages.  Check for latest builds:
+https://www.rust-lang.org/tools/install
+https://go.dev/dl/
+https://nim-lang.org/install.html
 
 ### Golang
 

--- a/arithmetic/build.gradle
+++ b/arithmetic/build.gradle
@@ -20,6 +20,7 @@ plugins {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
@@ -31,32 +32,32 @@ dependencies {
 }
 task macAarch64LibCopy(type: Copy) {
     from 'build/darwin-aarch64/lib/libeth_arithmetic.dylib'
-    into 'build/resources/main/darwin-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn macAarch64LibCopy
 
 
 task macLibCopy(type: Copy) {
     from 'build/darwin-x86-64/lib/libeth_arithmetic.dylib'
-    into 'build/resources/main/darwin-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
     from 'build/linux-gnu-x86_64/lib/libeth_arithmetic.so'
-    into 'build/resources/main/linux-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
     from 'build/linux-gnu-aarch64/lib/libeth_arithmetic.so'
-    into 'build/resources/main/linux-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 
 task linuxRiscv64LibCopy(type: Copy) {
     from 'build/linux-gnu-riscv64/lib/libeth_arithmetic.so'
-    into 'build/resources/main/linux-riscv64'
+    into 'build/resources/main/lib/riscv64'
 }
 processResources.dependsOn linuxRiscv64LibCopy
 

--- a/arithmetic/src/main/java/org/hyperledger/besu/nativelib/arithmetic/LibArithmetic.java
+++ b/arithmetic/src/main/java/org/hyperledger/besu/nativelib/arithmetic/LibArithmetic.java
@@ -16,8 +16,8 @@
 package org.hyperledger.besu.nativelib.arithmetic;
 
 import com.sun.jna.Library;
-import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibArithmetic implements Library {
 
@@ -28,7 +28,7 @@ public class LibArithmetic implements Library {
   static {
     boolean enabled;
     try {
-      Native.register(LibArithmetic.class, "eth_arithmetic");
+      BesuNativeLibraryLoader.registerJNA(LibArithmetic.class, "eth_arithmetic");
       enabled = true;
     } catch (final Exception t) {
       enabled = false;

--- a/blake2bf/build.gradle
+++ b/blake2bf/build.gradle
@@ -20,6 +20,7 @@ plugins {
 }
 
 dependencies {
+  implementation project(':common')
   implementation 'net.java.dev.jna:jna:5.12.1'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.assertj:assertj-core:3.22.0'
@@ -27,27 +28,27 @@ dependencies {
 
 task macAarch64LibCopy(type: Copy) {
   from 'build/darwin-aarch64/lib/libblake2bf.dylib'
-  into 'build/resources/main/darwin-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 
 processResources.dependsOn macAarch64LibCopy
 
 task macLibCopy(type: Copy) {
   from 'build/darwin-x86-64/lib/libblake2bf.dylib'
-  into 'build/resources/main/darwin-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 
 processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
   from 'build/linux-gnu-x86_64/lib/libblake2bf.so'
-  into 'build/resources/main/linux-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
   from 'build/linux-gnu-aarch64/lib/libblake2bf.so'
-  into 'build/resources/main/linux-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 

--- a/blake2bf/src/main/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bf.java
+++ b/blake2bf/src/main/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bf.java
@@ -16,8 +16,7 @@
 package org.hyperledger.besu.nativelib.blake2bf;
 
 import com.sun.jna.Library;
-import com.sun.jna.Native;
-import com.sun.jna.Platform;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibBlake2bf implements Library {
   @SuppressWarnings("WeakerAccess")
@@ -26,7 +25,7 @@ public class LibBlake2bf implements Library {
   static {
     boolean enabled;
     try {
-      Native.register(LibBlake2bf.class, "blake2bf");
+      BesuNativeLibraryLoader.registerJNA(LibBlake2bf.class, "blake2bf");
       enabled = true;
     } catch (final Throwable t) {
       enabled = false;

--- a/build.sh
+++ b/build.sh
@@ -282,7 +282,7 @@ EOF
     LIBRARY_EXTENSION=so
   elif [[ "$OSTYPE" == "darwin"* ]]; then
     LIBRARY_EXTENSION=dylib
-    export GOROOT=$(brew --prefix go@1.23)/libexec
+    export GOROOT=$(brew --prefix go@1.24)/libexec
     export PATH=$GOROOT/bin:$PATH
   fi
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    implementation 'net.java.dev.jna:jna:5.12.1'
+}
+jar {
+    archiveBaseName = 'common'
+    includeEmptyDirs = false
+    manifest {
+        attributes(
+                'Specification-Title': archiveBaseName,
+                'Specification-Version': project.version,
+                'Implementation-Title': archiveBaseName,
+                'Implementation-Version': project.version,
+                'Automatic-Module-Name': 'org.hyperledger.besu.nativelib.common'
+        )
+    }
+}
+

--- a/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
+++ b/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
@@ -24,13 +24,10 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Optional;
 
 public class BesuNativeLibraryLoader {
-
-  // base path for lib/arch.  replace underscore with dash to conform to jar packaging
-  static final String LIBRARY_RESOURCE_ARCH_PATH =
-      "lib/" + System.getProperty("os.arch").replace("_", "-") + "/";
 
   /**
    * Wraps JNA with a prescriptive path, removing any platform naming inconsistencies
@@ -112,7 +109,18 @@ public class BesuNativeLibraryLoader {
   private static String asLibraryResourcePath(String libraryName) {
 
     final String platformNativeLibraryName = System.mapLibraryName(libraryName);
-    return LIBRARY_RESOURCE_ARCH_PATH + platformNativeLibraryName;
+    return safeArchLib(platformNativeLibraryName);
 
+  }
+
+  // deal with the variants that might be reported for x86-64
+  static String[] X86_VARIANTS = {"amd64", "x86_64", "x64", "ia32e", "EMT64T"};
+  private static String safeArchLib(String platformNativeLibraryName) {
+    String arch = System.getProperty("os.arch");
+
+    if (Arrays.asList(X86_VARIANTS).contains(arch)) {
+      arch = "x86-64";
+    }
+    return String.format("lib/%s/%s", arch, platformNativeLibraryName );
   }
 }

--- a/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
+++ b/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
@@ -37,14 +37,14 @@ public class BesuNativeLibraryLoader {
    *  relies on the different operating systems to have different shared library object
    *  filenames.  E.g. .dylib vs .so vs .dll.
    */
-  public static void registerJNA(Class jniClass, String libraryName) {
+  public static void registerJNA(Class jnaClass, String libraryName) {
 
     try {
-      final Optional<Path> libPath = extract(jniClass, libraryName);
+      final Optional<Path> libPath = extract(jnaClass, libraryName);
 
       if (libPath.isPresent()) {
         NativeLibrary lib = NativeLibrary.getInstance(libPath.get().toString());
-        Native.register(jniClass, lib);
+        Native.register(jnaClass, lib);
       } else {
         throw new UnsatisfiedLinkError();
       }
@@ -77,17 +77,17 @@ public class BesuNativeLibraryLoader {
   }
 
 
-  private static Optional<Path> extract(Class jniClass, String libraryName) {
+  private static Optional<Path> extract(Class classResource, String libraryName) {
     final String platformNativeLibraryName = System.mapLibraryName(libraryName);
 
     // load from lib/arch.  replace underscore with dash to avoid platform arch naming oddities
     final String libraryResourcePath = asLibraryResourcePath(libraryName);
 
-    InputStream libraryResource = jniClass.getResourceAsStream(libraryResourcePath);
+    InputStream libraryResource = classResource.getResourceAsStream(libraryResourcePath);
 
     if (libraryResource == null) {
       // try absolute classpath reference for filesystem resources in case we are running tests:
-      libraryResource = jniClass.getResourceAsStream("/" + libraryResourcePath);
+      libraryResource = classResource.getResourceAsStream("/" + libraryResourcePath);
     }
 
     if (libraryResource != null) {

--- a/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
+++ b/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Besu Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
+package org.hyperledger.besu.nativelib.common;
+
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+public class BesuNativeLibraryLoader {
+
+  // base path for lib/arch.  replace underscore with dash to conform to jar packaging
+  static final String LIBRARY_RESOURCE_ARCH_PATH =
+      "lib/" + System.getProperty("os.arch").replace("_", "-") + "/";
+
+  /**
+   * Wraps JNA with a prescriptive path, removing any platform naming inconsistencies
+   *  that might exist.  E.g. linux-gnu-x86-64 vs linux-x86_64.
+   *
+   *  Note that this method expects the directory space to be "partitioned" only by the arch, and
+   *  relies on the different operating systems to have different shared library object
+   *  filenames.  E.g. .dylib vs .so vs .dll.
+   */
+  public static void registerJNA(Class jniClass, String libraryName) {
+
+    try {
+      final Optional<Path> libPath = extract(jniClass, libraryName);
+
+      if (libPath.isPresent()) {
+        NativeLibrary lib = NativeLibrary.getInstance(libPath.get().toString());
+        Native.register(jniClass, lib);
+      } else {
+        throw new UnsatisfiedLinkError();
+      }
+    } catch (UnsatisfiedLinkError __) {
+        String exceptionMessage =
+            String.format(
+                "Couldn't load native library (%s). It wasn't available at %s or the library path.",
+                libraryName, asLibraryResourcePath(libraryName));
+        throw new RuntimeException(exceptionMessage);
+    }
+  }
+
+  public static void loadJNI(Class jniClass, String libraryName) {
+
+    try {
+      final Optional<Path> libPath = extract(jniClass, libraryName);
+
+      if (libPath.isPresent()) {
+        System.load(libPath.get().toString());
+      } else {
+        System.loadLibrary(libraryName);
+      }
+    } catch (UnsatisfiedLinkError __) {
+      String exceptionMessage =
+          String.format(
+              "Couldn't load native library (%s). It wasn't available at %s or the library path.",
+              libraryName, asLibraryResourcePath(libraryName));
+      throw new RuntimeException(exceptionMessage);
+    }
+  }
+
+
+  private static Optional<Path> extract(Class jniClass, String libraryName) {
+    final String platformNativeLibraryName = System.mapLibraryName(libraryName);
+
+    // load from lib/arch.  replace underscore with dash to avoid platform arch naming oddities
+    final String libraryResourcePath = asLibraryResourcePath(libraryName);
+
+    InputStream libraryResource = jniClass.getResourceAsStream(libraryResourcePath);
+
+    if (libraryResource == null) {
+      // try absolute classpath reference for filesystem resources in case we are running tests:
+      libraryResource = jniClass.getResourceAsStream("/" + libraryResourcePath);
+    }
+
+    if (libraryResource != null) {
+      try {
+        Path tempDir = Files.createTempDirectory(libraryName + "@");
+        tempDir.toFile().deleteOnExit();
+        Path tempDll = tempDir.resolve(platformNativeLibraryName);
+        tempDll.toFile().deleteOnExit();
+        Files.copy(libraryResource, tempDll, StandardCopyOption.REPLACE_EXISTING);
+        libraryResource.close();
+        return Optional.of(tempDll);
+      } catch (IOException ex) {
+        throw new UncheckedIOException(ex);
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static String asLibraryResourcePath(String libraryName) {
+
+    final String platformNativeLibraryName = System.mapLibraryName(libraryName);
+    return LIBRARY_RESOURCE_ARCH_PATH + platformNativeLibraryName;
+
+  }
+}

--- a/constantine/build.gradle
+++ b/constantine/build.gradle
@@ -9,6 +9,7 @@ repositories {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
@@ -27,23 +28,23 @@ tasks.withType(JavaCompile) {
 
 task macArmLibCopy(type: Copy) {
     from "build/darwin-aarch64/lib/libconstantinebindings.dylib"
-    into 'build/resources/main/darwin-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 
 task macLibCopy(type: Copy) {
     from "build/darwin-x86-64/lib/libconstantinebindings.dylib"
-    into 'build/resources/main/darwin-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 
 task linuxLibCopy(type: Copy) {
     from "build/linux-gnu-x86_64/lib/libconstantinebindings.so"
-    into 'build/resources/main/linux-gnu-x86_64'
+    into 'build/resources/main/lib/x86-64'
 
 }
 
 task linuxArm64LibCopy(type: Copy) {
     from "build/linux-gnu-aarch64/lib/libconstantinebindings.so"
-    into 'build/resources/main/linux-gnu-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 
 processResources.dependsOn macArmLibCopy, macLibCopy, linuxLibCopy, linuxArm64LibCopy

--- a/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196.java
+++ b/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196.java
@@ -1,6 +1,6 @@
 package org.hyperledger.besu.nativelib.constantine;
 
-import com.sun.jna.Native;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibConstantineEIP196 {
     public static final boolean ENABLED;
@@ -8,7 +8,7 @@ public class LibConstantineEIP196 {
     static {
         boolean enabled;
         try {
-            Native.register(LibConstantineEIP196.class, "constantinebindings");
+            BesuNativeLibraryLoader.registerJNA(LibConstantineEIP196.class, "constantinebindings");
             enabled = true;
         } catch (final Throwable t) {
             t.printStackTrace();

--- a/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537.java
+++ b/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537.java
@@ -1,6 +1,6 @@
 package org.hyperledger.besu.nativelib.constantine;
 
-import com.sun.jna.Native;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibConstantineEIP2537 {
     public static final boolean ENABLED;
@@ -8,7 +8,7 @@ public class LibConstantineEIP2537 {
     static {
         boolean enabled;
         try {
-            Native.register(LibConstantineEIP2537.class, "constantinebindings");
+            BesuNativeLibraryLoader.registerJNA(LibConstantineEIP2537.class, "constantinebindings");
             enabled = true;
         } catch (final Throwable t) {
             t.printStackTrace();

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -21,6 +21,7 @@ plugins {
 
 dependencies {
     implementation 'net.java.dev.jna:jna:5.12.1'
+    implementation project(':common')
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'net.java.dev.jna:jna:5.12.1'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
@@ -33,7 +34,7 @@ task macArmLibCopy(type: Copy) {
     from 'build/darwin-aarch64/lib/libgnark_jni.dylib'
     from 'build/darwin-aarch64/lib/libgnark_eip_2537.dylib'
     from 'build/darwin-aarch64/lib/libgnark_eip_196.dylib'
-    into 'build/resources/main/darwin-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn macArmLibCopy
 
@@ -41,7 +42,7 @@ task macLibCopy(type: Copy) {
     from 'build/darwin-x86-64/lib/libgnark_jni.dylib'
     from 'build/darwin-x86-64/lib/libgnark_eip_2537.dylib'
     from 'build/darwin-x86-64/lib/libgnark_eip_196.dylib'
-    into 'build/resources/main/darwin-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn macLibCopy
 
@@ -49,7 +50,7 @@ task linuxLibCopy(type: Copy) {
     from 'build/linux-gnu-x86_64/lib/libgnark_jni.so'
     from 'build/linux-gnu-x86_64/lib/libgnark_eip_2537.so'
     from 'build/linux-gnu-x86_64/lib/libgnark_eip_196.so'
-    into 'build/resources/main/linux-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
@@ -57,7 +58,7 @@ task linuxArm64LibCopy(type: Copy) {
     from 'build/linux-gnu-aarch64/lib/libgnark_jni.so'
     from 'build/linux-gnu-aarch64/lib/libgnark_eip_2537.so'
     from 'build/linux-gnu-aarch64/lib/libgnark_eip_196.so'
-    into 'build/resources/main/linux-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 
@@ -65,7 +66,7 @@ task linuxRiscv64LibCopy(type: Copy) {
     from 'build/linux-gnu-riscv64/lib/libgnark_jni.so'
     from 'build/linux-gnu-riscv64/lib/libgnark_eip_2537.so'
     from 'build/linux-gnu-riscv64/lib/libgnark_eip_196.so'
-    into 'build/resources/main/linux-riscv64'
+    into 'build/resources/main/lib/riscv64'
 }
 processResources.dependsOn linuxRiscv64LibCopy
 

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
@@ -15,7 +15,7 @@
  */
 package org.hyperledger.besu.nativelib.gnark;
 
-import com.sun.jna.Native;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 /**
  * Java interface to gnark
@@ -28,7 +28,7 @@ public class LibGnark {
     static {
         boolean enabled;
         try {
-            Native.register(LibGnark.class, "gnark_jni");
+            BesuNativeLibraryLoader.registerJNA(LibGnark.class, "gnark_jni");
             enabled = true;
         } catch (final Throwable t) {
             t.printStackTrace();

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
@@ -1,7 +1,7 @@
 package org.hyperledger.besu.nativelib.gnark;
 
-import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibGnarkEIP196 {
 
@@ -17,7 +17,7 @@ public class LibGnarkEIP196 {
   static {
     boolean enabled;
     try {
-      Native.register(LibGnarkEIP196.class, "gnark_eip_196");
+      BesuNativeLibraryLoader.registerJNA(LibGnarkEIP196.class, "gnark_eip_196");
       enabled = true;
     } catch (final Throwable t) {
       t.printStackTrace();

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
@@ -1,8 +1,8 @@
 package org.hyperledger.besu.nativelib.gnark;
 
 import com.sun.jna.Library;
-import com.sun.jna.Native;
 import com.sun.jna.ptr.IntByReference;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibGnarkEIP2537 implements Library {
 
@@ -15,7 +15,7 @@ public class LibGnarkEIP2537 implements Library {
   static {
     boolean enabled;
     try {
-      Native.register(LibGnarkEIP2537.class, "gnark_eip_2537");
+      BesuNativeLibraryLoader.registerJNA(LibGnarkEIP2537.class, "gnark_eip_2537");
       enabled = true;
     } catch (final Throwable t) {
       t.printStackTrace();

--- a/ipa-multipoint/build.gradle
+++ b/ipa-multipoint/build.gradle
@@ -20,13 +20,14 @@ plugins {
 }
 
 dependencies {
-    implementation 'net.java.dev.jna:jna:5.12.1'
+  implementation project(':common')
+  implementation 'net.java.dev.jna:jna:5.12.1'
   testImplementation 'io.tmio:tuweni-bytes:2.4.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
+  testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
+  testImplementation 'org.assertj:assertj-core:3.22.0'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }
 
 test {
@@ -43,31 +44,31 @@ sourceSets {
 
 task macArmLibCopy(type: Copy) {
   from 'build/darwin-aarch64/lib/libipa_multipoint_jni.dylib'
-  into 'build/resources/main/darwin-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
   from 'build/darwin-x86-64/lib/libipa_multipoint_jni.dylib'
-  into 'build/resources/main/darwin-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
   from 'build/linux-gnu-x86_64/lib/libipa_multipoint_jni.so'
-  into 'build/resources/main/linux-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
   from 'build/linux-gnu-aarch64/lib/libipa_multipoint_jni.so'
-  into 'build/resources/main/linux-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 
 task linuxRiscv64LibCopy(type: Copy) {
   from 'build/linux-gnu-riscv64/lib/libipa_multipoint_jni.so'
-  into 'build/resources/main/linux-riscv64'
+  into 'build/resources/main/lib/riscv64'
 }
 processResources.dependsOn linuxRiscv64LibCopy
 

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -15,10 +15,11 @@
  */
 package org.hyperledger.besu.nativelib.ipamultipoint;
 
+import com.sun.jna.Library;
 import com.sun.jna.Native;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 import java.io.File;
-import java.io.IOException;
 
 /**
  * Java interface to ipa-multipoint, a rust library that supports computing polynomial commitments.
@@ -26,7 +27,7 @@ import java.io.IOException;
  * The library relies on the bandersnatch curve described at https://eprint.iacr.org/2021/1152.pdf.
  *
  */
-public class LibIpaMultipoint {
+public class LibIpaMultipoint implements Library {
 
   @SuppressWarnings("WeakerAccess")
   public static final boolean ENABLED;
@@ -34,10 +35,9 @@ public class LibIpaMultipoint {
   static {
     boolean enabled;
     try {
-      File lib = Native.extractFromResourcePath("ipa_multipoint_jni");
-      System.load(lib.getAbsolutePath());
+      BesuNativeLibraryLoader.loadJNI(LibIpaMultipoint.class, "ipa_multipoint_jni");
       enabled = true;
-    } catch (IOException e) {
+    } catch (Exception e) {
       enabled = false;
     }
     ENABLED = enabled;

--- a/native-build.sh
+++ b/native-build.sh
@@ -4,7 +4,7 @@ DEBIAN_FRONTEND=non-interactive apt-get install -y autoconf build-essential libt
 export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
 export PATH=$JAVA_HOME/bin:$PATH
 wget https://go.dev/dl/go1.24.1.linux-arm64.tar.gz
-echo "faec7f7f8ae53fda0f3d408f52182d942cc89ef5b7d3d9f23ff117437d4b2d2f  go1.24.1.linux-arm64.tar.gz" | sha256sum -c || exit 1
+echo "8df5750ffc0281017fb6070fba450f5d22b600a02081dceef47966ffaf36a3af  go1.24.1.linux-arm64.tar.gz" | sha256sum -c || exit 1
 tar -xzf go1.24.1.linux-arm64.tar.gz -C $HOME
 export GOPATH=$HOME/.go
 mkdir -p $GOPATH

--- a/native-build.sh
+++ b/native-build.sh
@@ -3,9 +3,9 @@ apt-get update
 DEBIAN_FRONTEND=non-interactive apt-get install -y autoconf build-essential libtool automake patchelf curl openjdk-21-jdk git wget
 export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
 export PATH=$JAVA_HOME/bin:$PATH
-wget https://go.dev/dl/go1.23.1.linux-arm64.tar.gz
-echo "faec7f7f8ae53fda0f3d408f52182d942cc89ef5b7d3d9f23ff117437d4b2d2f  go1.23.1.linux-arm64.tar.gz" | sha256sum -c || exit 1
-tar -xzf go1.23.1.linux-arm64.tar.gz -C $HOME
+wget https://go.dev/dl/go1.24.1.linux-arm64.tar.gz
+echo "faec7f7f8ae53fda0f3d408f52182d942cc89ef5b7d3d9f23ff117437d4b2d2f  go1.24.1.linux-arm64.tar.gz" | sha256sum -c || exit 1
+tar -xzf go1.24.1.linux-arm64.tar.gz -C $HOME
 export GOPATH=$HOME/.go
 mkdir -p $GOPATH
 export GOROOT="$HOME/go"

--- a/secp256k1/build.gradle
+++ b/secp256k1/build.gradle
@@ -20,36 +20,37 @@ plugins {
 }
 
 dependencies {
+  implementation project(':common')
   implementation 'net.java.dev.jna:jna:5.12.1'
 }
 
 task macArmLibCopy(type: Copy) {
   from 'build/darwin-aarch64/lib/libsecp256k1.dylib'
-  into 'build/resources/main/darwin-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
   from 'build/darwin-x86-64/lib/libsecp256k1.dylib'
-  into 'build/resources/main/darwin-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
   from 'build/linux-gnu-x86_64/lib/libsecp256k1.so'
-  into 'build/resources/main/linux-x86-64'
+  into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
   from 'build/linux-gnu-aarch64/lib/libsecp256k1.so'
-  into 'build/resources/main/linux-aarch64'
+  into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 
 task linuxRiscv64LibCopy(type: Copy) {
   from 'build/linux-gnu-riscv64/lib/libsecp256k1.so'
-  into 'build/resources/main/linux-riscv64'
+  into 'build/resources/main/lib/riscv64'
 }
 processResources.dependsOn linuxRiscv64LibCopy
 

--- a/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
+++ b/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
@@ -20,13 +20,13 @@ import java.security.SecureRandom;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
-import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Structure.FieldOrder;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.ptr.LongByReference;
 import com.sun.jna.ptr.PointerByReference;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 
 public class LibSecp256k1 implements Library {
 
@@ -53,7 +53,7 @@ public class LibSecp256k1 implements Library {
 
   private static PointerByReference createContext() {
     try {
-      Native.register(LibSecp256k1.class, "secp256k1");
+      BesuNativeLibraryLoader.registerJNA(LibSecp256k1.class, "secp256k1");
       final PointerByReference context =
           secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
       if (Boolean.parseBoolean(System.getProperty("secp256k1.randomize", "true"))) {

--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -20,8 +20,8 @@ plugins {
 }
 
 dependencies {
+    implementation project(':common')
     implementation 'net.java.dev.jna:jna:5.12.1'
-
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
@@ -39,35 +39,35 @@ tasks.named('compileTestJava').configure {
 task macArmLibCopy(type: Copy) {
     from 'besu-native-ec/release/darwin-aarch64/libbesu_native_ec.dylib'
     from 'besu-native-ec/release/darwin-aarch64/libbesu_native_ec_crypto.dylib'
-    into 'build/resources/main/darwin-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn macArmLibCopy
 
 task macLibCopy(type: Copy) {
     from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec.dylib'
     from 'besu-native-ec/release/darwin-x86-64/libbesu_native_ec_crypto.dylib'
-    into 'build/resources/main/darwin-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn macLibCopy
 
 task linuxLibCopy(type: Copy) {
     from 'besu-native-ec/release/linux-gnu-x86_64/libbesu_native_ec.so'
     from 'besu-native-ec/release/linux-gnu-x86_64/libbesu_native_ec_crypto.so'
-    into 'build/resources/main/linux-x86-64'
+    into 'build/resources/main/lib/x86-64'
 }
 processResources.dependsOn linuxLibCopy
 
 task linuxArm64LibCopy(type: Copy) {
     from 'besu-native-ec/release/linux-gnu-aarch64/libbesu_native_ec.so'
     from 'besu-native-ec/release/linux-gnu-aarch64/libbesu_native_ec_crypto.so'
-    into 'build/resources/main/linux-aarch64'
+    into 'build/resources/main/lib/aarch64'
 }
 processResources.dependsOn linuxArm64LibCopy
 
 task linuxRiscv64LibCopy(type: Copy) {
     from 'besu-native-ec/release/linux-gnu-riscv64/libbesu_native_ec.so'
     from 'besu-native-ec/release/linux-gnu-riscv64/libbesu_native_ec_crypto.so'
-    into 'build/resources/main/linux-riscv64'
+    into 'build/resources/main/lib/riscv64'
 }
 processResources.dependsOn linuxRiscv64LibCopy
 

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
@@ -14,7 +14,7 @@ public class LibSECP256R1 {
 
     public byte[] keyRecovery(final byte[] dataHash, final byte[] signatureR, final byte[] signatureS,
                               final int signatureV) throws IllegalArgumentException {
-        final KeyRecoveryResultByValue result = BesuNativeEC.INSTANCE.p256_key_recovery(
+        final KeyRecoveryResultByValue result = BesuNativeEC.p256_key_recovery(
                 dataHash,
                 dataHash.length,
                 convertToNativeRepresentation(signatureR),
@@ -32,7 +32,7 @@ public class LibSECP256R1 {
     }
 
     public Signature sign(byte[] dataHash, byte[] privateKey, byte[] publicKey) throws IllegalArgumentException {
-        final SignResultByValue result = BesuNativeEC.INSTANCE.p256_sign(
+        final SignResultByValue result = BesuNativeEC.p256_sign(
                 dataHash, dataHash.length, privateKey, publicKey);
 
         String errorMessage = (new String(result.error_message)).trim();
@@ -50,7 +50,7 @@ public class LibSECP256R1 {
 
     public boolean verify(final byte[] dataHash, final byte[] signatureR, final byte[] signatureS,
                           final byte[] publicKey) throws IllegalArgumentException {
-        final VerifyResultByValue result = BesuNativeEC.INSTANCE.p256_verify(
+        final VerifyResultByValue result = BesuNativeEC.p256_verify(
                 dataHash,
                 dataHash.length,
                 convertToNativeRepresentation(signatureR),

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
@@ -15,29 +15,39 @@
 
 package org.hyperledger.besu.nativelib.secp256r1.besuNativeEC;
 
+import com.sun.jna.Library;
+import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;
 import org.hyperledger.besu.nativelib.secp256r1.besuNativeEC.KeyRecoveryResult.KeyRecoveryResultByValue;
 import org.hyperledger.besu.nativelib.secp256r1.besuNativeEC.SignResult.SignResultByValue;
 import org.hyperledger.besu.nativelib.secp256r1.besuNativeEC.VerifyResult.VerifyResultByValue;
 
-import com.sun.jna.Library;
-import com.sun.jna.Native;
+public class BesuNativeEC implements Library {
+	public static final boolean ENABLED;
 
-public interface BesuNativeEC extends Library {
-	Library OPEN_SSL_LIB_CRYPTO = Native.load("besu_native_ec_crypto", Library.class);
-	BesuNativeEC INSTANCE = Native.load("besu_native_ec", BesuNativeEC.class);
+	static {
+		boolean enabled;
+		try {
+			BesuNativeLibraryLoader.registerJNA(Library.class, "besu_native_ec_crypto");
+			BesuNativeLibraryLoader.registerJNA(BesuNativeEC.class, "besu_native_ec");
+			enabled = true;
+		} catch (final Exception t) {
+			enabled = false;
+		}
+		ENABLED = enabled;
+	}
 
 	/**
 	 * Original signature : <code>key_recovery_result p256_key_recovery(const char[], const int, const char[], const char[], int)</code><br>
 	 */
-	KeyRecoveryResultByValue p256_key_recovery(byte[] data_hash, int data_hash_len, byte[] signature_r_hex, byte[] signature_s_hex, int signature_v);
+	public static native KeyRecoveryResultByValue p256_key_recovery(byte[] data_hash, int data_hash_len, byte[] signature_r_hex, byte[] signature_s_hex, int signature_v);
 
 	/**
 	 * Original signature : <code>sign_result p256_sign(const char[], const int, const char[], const char[])</code><br>
 	 */
-	SignResultByValue p256_sign(byte[] data_hash, int data_hash_length, byte[] private_key_data, byte[] public_key_data);
+	public static native SignResultByValue p256_sign(byte[] data_hash, int data_hash_length, byte[] private_key_data, byte[] public_key_data);
 
 	/**
 	 * Original signature : <code>verify_result p256_verify(const char[], const int, const char[], const char[], const char[])</code><br>
 	 */
-	VerifyResultByValue p256_verify(byte[] data_hash, int data_hash_length, byte[] signature_r, byte[] signature_s, byte[] public_key_data);
+	public static native VerifyResultByValue p256_verify(byte[] data_hash, int data_hash_length, byte[] signature_r, byte[] signature_s, byte[] public_key_data);
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@
  */
 
 rootProject.name='besu-native'
+include 'common'
 include 'arithmetic'
 include 'blake2bf'
 include 'ipa-multipoint'


### PR DESCRIPTION
Use explict paths based on arch in besu-native during the library builds, and during library loading.  We are still using JNA for jna libraries, and jni for jni libraries.  However we are using conformed arch names to publish and find native libs.  This should resolve the OSTYPE and OSARCH naming problems that seem to plague linux distributions especially.

fixes #242 
is blocking [#8432](https://github.com/hyperledger/besu/issues/8342)

Tested on:
* Mac Os 15.3.1 on M2max
* Ubuntu 24.04 on x86_64
* Pop! OS linux 22.04 x86_64
* Armbian Linux 24.8.4 on riscv64
* Armbian Linux 24.5.5 on arm64

Build fails on:
* Mac Os 10.15.7 on X86 (❌ build fails, OS toolchain is too old to know how to build a lipo lib)