### PR TITLE
Update constantine to v0.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           export CARGO_HOME="$HOME/.cargo"
           curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.75.0
           # nim dependencies
-          export CHOOSENIM_CHOOSE_VERSION=2.0.4
+          export CHOOSENIM_CHOOSE_VERSION=2.2.2
           curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
           export PATH=$HOME/.nimble/bin:$PATH
       - name: Checkout Repo
@@ -163,7 +163,7 @@ jobs:
           rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
           # nim dependencies
-          export CHOOSENIM_CHOOSE_VERSION=2.0.4
+          export CHOOSENIM_CHOOSE_VERSION=2.2.2
           curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
           export PATH=$HOME/.nimble/bin:$PATH
       - name: Checkout Repo
@@ -230,7 +230,7 @@ jobs:
           rustup target add x86_64-apple-darwin
           rustup target add aarch64-apple-darwin
           # nim dependencies
-          export CHOOSENIM_CHOOSE_VERSION=2.0.4
+          export CHOOSENIM_CHOOSE_VERSION=2.2.2
           curl https://nim-lang.org/choosenim/init.sh -sSf | sh -s -- -y
           export PATH=$HOME/.nimble/bin:$PATH
       - name: Checkout Repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 # Unreleased
+* bump constantine submodule to v0.2 and nim compiler version to 2.2.2
 * refactor library loading to conform arch names [#245](https://github.com/hyperledger/besu-native/pull/245)
 * bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements [#240](https://github.com/hyperledger/besu-native/pull/240)
 * add riscv64 support for building besu-native, no CI support yet [#244](https://github.com/hyperledger/besu-native/pull/244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # Unreleased
-* bump constantine submodule to v0.2 and nim compiler version to 2.2.2
+* bump constantine to v0.2.0 and nim to 2.2.2 [#246](https://github.com/hyperledger/besu-native/pull/246)
 * refactor library loading to conform arch names [#245](https://github.com/hyperledger/besu-native/pull/245)
 * bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements [#240](https://github.com/hyperledger/besu-native/pull/240)
 * add riscv64 support for building besu-native, no CI support yet [#244](https://github.com/hyperledger/besu-native/pull/244)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://go.dev/dl/
 
 ### Nim
 
-Nim is required to build Constantine.  Constantine is skipped on riscv64 architectures, so it is not needed for linux-riscv64.
+Nim 2.2.x+ is required to build Constantine.  Constantine is skipped on riscv64 architectures, so it is not needed for linux-riscv64.
 On MacOs, homebrew has a working nim target, e.g.:
 
 `brew install nim`

--- a/build.sh
+++ b/build.sh
@@ -335,6 +335,8 @@ build_constantine() {
     tar -xf nim-2.2.2-linux_arm64.tar.xz
     git config --global --add safe.directory /home/ubuntu/constantine/constantine
     export PATH=$(pwd)/nim-2.2.2/bin:$PATH
+    # arm64 ASM is currently only for apple silicon processors, revisit in future releases of constantine:
+    export CTT_ASM=0
     nimble make_lib
   else
     export PATH=$HOME/.nimble/bin:$PATH

--- a/build.sh
+++ b/build.sh
@@ -329,10 +329,12 @@ build_constantine() {
   export CTT_LTO=false
   if [[ "$OSARCH" == "linux-gnu-aarch64" ]]; then
     # Download and extract Nim
-    wget https://github.com/nim-lang/nightlies/releases/download/2024-03-28-version-2-0-b47747d31844c6bd9af4322efe55e24fefea544c/nim-2.0.4-linux_arm64.tar.xz
-    tar -xf nim-2.0.4-linux_arm64.tar.xz
+    wget https://github.com/nim-lang/nightlies/releases/download/2025-02-14-version-2-2-6c34f62785263ad412f662f3e4e4bf8d8751d113/nim-2.2.2-linux_arm64.tar.xz
+    # verify download sha
+    echo "d983fadd58afd78b0dda5f690b03bf0ba2ee034e3476f4c62cbbe352ffc4656b nim-2.2.2-linux_arm64.tar.xz" | sha256sum -c || exit 1
+    tar -xf nim-2.2.2-linux_arm64.tar.xz
     git config --global --add safe.directory /home/ubuntu/constantine/constantine
-    export PATH=$(pwd)/nim-2.0.4/bin:$PATH
+    export PATH=$(pwd)/nim-2.2.2/bin:$PATH
     nimble make_lib
   else
     export PATH=$HOME/.nimble/bin:$PATH


### PR DESCRIPTION
## Description

Constantine has significant improvements in the [0.2.0 release](https://github.com/mratsim/constantine/releases/tag/v0.2.0)
Additionally, package managers have moved to 2.2.x versions of nim, which the v0.1.0 release of Constantine cannot compile against.  Since v0.2.0  is compatible with the latest nim compiler releases, it makes sense to update both constantine and nim.


* bump constantine submodule to [v0.2.0](https://github.com/mratsim/constantine/releases/tag/v0.2.0)
* bump choosenim nim compiler downloads to [2.2.2](https://github.com/nim-lang/Nim/releases/tag/v2.2.2)
* bump linux-arm64 nightly build of nim to 2.2.2 version, sha matched to 2.2.2 release tag version
* updates GHA CI pipeline nim version to 2.2.2
* update README.md with nim version requirements

## Fixes
* local build problem found on MacOS intel platforms by using latest nim from sources