### PR TITLE
release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 # Unreleased
+
+# 1.2.0
+Pectra mainnet support release
 * bump constantine to v0.2.0 and nim to 2.2.2 [#246](https://github.com/hyperledger/besu-native/pull/246)
 * refactor library loading to conform arch names [#245](https://github.com/hyperledger/besu-native/pull/245)
 * bump gnark-crypto to 0.16.0, adds avx512 support and ARM assembly performance improvements [#240](https://github.com/hyperledger/besu-native/pull/240)


### PR DESCRIPTION
Release 1.2.0 to support pectra mainnet.

Besu has a hard dependency on besu-native for pectra hardfork.  This release makes library loading more robust across a variety of platforms