### PR TITLE
Release 1.2.1 - Errata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+# 1.2.1
+Errata release
+* include besu-native-common in published packages [#252](https://github.com/hyperledger/besu-native/pull/252)
+
 # 1.2.0
 Pectra mainnet support release
 * bump constantine to v0.2.0 and nim to 2.2.2 [#246](https://github.com/hyperledger/besu-native/pull/246)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-version=1.2.1-SNAPSHOT
-
+version=1.2.1


### PR DESCRIPTION
Add besu-native-common to the list of published packages in CI

# 1.2.1
Errata release
* include besu-native-common in published packages [#252](https://github.com/hyperledger/besu-native/pull/252)

