### PR TITLE
Enable malleable signature verification for secp256r1

### DIFF
--- a/secp256r1/build.gradle
+++ b/secp256r1/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:31.1-jre'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'io.tmio:tuweni-bytes:2.4.2'
+    testImplementation 'io.tmio:tuweni-units:2.4.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
@@ -49,13 +49,25 @@ public class LibSECP256R1 {
     }
 
     public boolean verify(final byte[] dataHash, final byte[] signatureR, final byte[] signatureS,
-                          final byte[] publicKey) throws IllegalArgumentException {
-        final VerifyResultByValue result = BesuNativeEC.p256_verify(
+        final byte[] publicKey) throws IllegalArgumentException {
+        return verify(dataHash, signatureR, signatureS, publicKey, false);
+    }
+
+    public boolean verify(final byte[] dataHash, final byte[] signatureR, final byte[] signatureS,
+        final byte[] publicKey, final boolean allowMalleable) throws IllegalArgumentException {
+        VerifyResultByValue result;
+        if (!allowMalleable) {
+            result = BesuNativeEC.p256_verify(dataHash, dataHash.length,
+                convertToNativeRepresentation(signatureR),
+                convertToNativeRepresentation(signatureS), publicKey);
+        } else {
+            result = BesuNativeEC.p256_verify_malleable_signature(
                 dataHash,
                 dataHash.length,
                 convertToNativeRepresentation(signatureR),
                 convertToNativeRepresentation(signatureS),
                 publicKey);
+        }
 
         if (result.verified < 0) {
             String errorMessage = (new String(result.error_message)).trim();

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
@@ -50,4 +50,9 @@ public class BesuNativeEC implements Library {
 	 * Original signature : <code>verify_result p256_verify(const char[], const int, const char[], const char[], const char[])</code><br>
 	 */
 	public static native VerifyResultByValue p256_verify(byte[] data_hash, int data_hash_length, byte[] signature_r, byte[] signature_s, byte[] public_key_data);
+
+	/**
+	 * Original signature : <code>verify_result p256_verify_malleable_signature(const char[], const int, const char[], const char[], const char[])</code><br>
+	 */
+	public static native VerifyResultByValue p256_verify_malleable_signature(byte[] data_hash, int data_hash_length, byte[] signature_r, byte[] signature_s, byte[] public_key_data);
 }


### PR DESCRIPTION
Adds the overload from besu-native-ec for p256_verify_malleated_signature

motivation: support for [EIP-7951](https://github.com/ethereum/EIPs/pull/9833/files?short_path=e3d4e97#diff-e3d4e9768cba978506e431cac1b9198302825e58170366b0fad5229f6fb90030)

related to [issue 8605](https://github.com/hyperledger/besu/issues/8605)
related to [pr 8750](https://github.com/hyperledger/besu/pull/8750)
