### PR TITLE
[MINOR] Don't force ssh on besu-native builders

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/bitcoin-core/secp256k1.git
 [submodule "secp256r1/besu-native-ec"]
 	path = secp256r1/besu-native-ec
-	url = git@github.com:ConsenSys/besu-native-ec.git
+	url = https://github.com/ConsenSys/besu-native-ec.git
 [submodule "constantine/constantine"]
 	path = constantine/constantine
 	url = https://github.com/mratsim/constantine.git


### PR DESCRIPTION
This makes it easier to build besu-native on a benchmarking machine that might not have a git ssh key setup for example