### PR TITLE
Add and correct licenses

### DIFF
--- a/arithmetic/arithmetic/src/arith.rs
+++ b/arithmetic/arithmetic/src/arith.rs
@@ -1,3 +1,15 @@
+/* Copyright contributors to Besu.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use crate::{
     mpnat::{DoubleWord, MPNat, Word, BASE, WORD_BITS},
 };

--- a/arithmetic/arithmetic/src/lib.rs
+++ b/arithmetic/arithmetic/src/lib.rs
@@ -1,6 +1,15 @@
-// Copyright contributors to Hyperledger Besu
-// SPDX-License-Identifier: Apache-2.0
-
+/* Copyright contributors to Besu.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 mod arith;
 mod mpnat;
 

--- a/arithmetic/arithmetic/src/mpnat.rs
+++ b/arithmetic/arithmetic/src/mpnat.rs
@@ -1,3 +1,15 @@
+/* Copyright contributors to Besu.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use crate::{
     arith::{
         big_wrapping_mul, big_wrapping_pow, borrowing_sub, carrying_add, compute_r_mod_n,

--- a/arithmetic/src/main/java/org/hyperledger/besu/nativelib/arithmetic/LibArithmetic.java
+++ b/arithmetic/src/main/java/org/hyperledger/besu/nativelib/arithmetic/LibArithmetic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright contributors to Hyperledger Besu
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/arithmetic/src/test/java/org/hyperledger/besu/nativelib/arithmetic/TestLibArithmetic.java
+++ b/arithmetic/src/test/java/org/hyperledger/besu/nativelib/arithmetic/TestLibArithmetic.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.arithmetic;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/blake2bf/src/main/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bf.java
+++ b/blake2bf/src/main/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu Contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
+++ b/blake2bf/src/test/java/org/hyperledger/besu/nativelib/blake2bf/LibBlake2bfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu Contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 package org.hyperledger.besu.nativelib.blake2bf;
 

--- a/boringssl/boringssl_jni/ecrecover.c
+++ b/boringssl/boringssl_jni/ecrecover.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #include "ecrecover.h"
 
 #include <openssl/bn.h>

--- a/boringssl/boringssl_jni/ecrecover.h
+++ b/boringssl/boringssl_jni/ecrecover.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #ifndef ECRECOVER_H
 #define ECRECOVER_H
 

--- a/boringssl/boringssl_jni/p256_verify.c
+++ b/boringssl/boringssl_jni/p256_verify.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #include "p256_verify.h"
 
 #include <openssl/bn.h>

--- a/boringssl/boringssl_jni/p256_verify.h
+++ b/boringssl/boringssl_jni/p256_verify.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #ifndef P256_VERIFY_H
 #define P256_VERIFY_H
 

--- a/boringssl/build.gradle
+++ b/boringssl/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/boringssl/src/main/java/org/hyperledger/besu/nativelib/boringssl/BoringSSLPrecompiles.java
+++ b/boringssl/src/main/java/org/hyperledger/besu/nativelib/boringssl/BoringSSLPrecompiles.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.boringssl;
 
 import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;

--- a/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256EdgeCaseTest.java
+++ b/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256EdgeCaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.boringssl;
 
 import org.apache.tuweni.bytes.Bytes;

--- a/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256VerifyParameterizedTest.java
+++ b/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256VerifyParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.boringssl;
 
 import com.google.common.io.CharStreams;

--- a/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256VerifyTest.java
+++ b/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/P256VerifyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.boringssl;
 
 import org.apache.tuweni.bytes.Bytes;

--- a/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/SecP256R1EcrecoverParameterizedTest.java
+++ b/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/SecP256R1EcrecoverParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.boringssl;
 
 import com.google.common.io.CharStreams;

--- a/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/SecP256R1EcrecoverTest.java
+++ b/boringssl/src/test/java/org/hyperledger/besu/nativelib/boringssl/SecP256R1EcrecoverTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.boringssl;
 
 import org.apache.tuweni.bytes.Bytes;

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
+++ b/common/src/main/java/org/hyperledger/besu/nativelib/common/BesuNativeLibraryLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/constantine/jna_ethereum_evm_precompiles.c
+++ b/constantine/jna_ethereum_evm_precompiles.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #include <constantine.h>
 #include <stdio.h>
 

--- a/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196.java
+++ b/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;

--- a/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537.java
+++ b/constantine/src/main/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import org.hyperledger.besu.nativelib.common.BesuNativeLibraryLoader;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196G1AddTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196G1AddTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196G1MulTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196G1MulTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196PairingCheckTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP196PairingCheckTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537FpToG1Test.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537FpToG1Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1AddTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1AddTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1MsmTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1MsmTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1MulTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G1MulTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2AddTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2AddTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2MsmTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2MsmTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2MulTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537G2MulTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.io.CharStreams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537PairingCheckTest.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/ConstantineEIP2537PairingCheckTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import com.google.common.collect.Streams;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196Test.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP196Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import org.junit.Test;

--- a/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537Test.java
+++ b/constantine/src/test/java/org/hyperledger/besu/nativelib/constantine/LibConstantineEIP2537Test.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.constantine;
 
 import org.junit.Test;

--- a/gnark/build.gradle
+++ b/gnark/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/gnark-jni/gnark-eip-196.go
+++ b/gnark/gnark-jni/gnark-eip-196.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package main
 
 /*

--- a/gnark/gnark-jni/gnark-eip-2537.go
+++ b/gnark/gnark-jni/gnark-eip-2537.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package main
 
 /*

--- a/gnark/gnark-jni/gnark-jni.go
+++ b/gnark/gnark-jni/gnark-jni.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package main
 
 import "C"

--- a/gnark/gnark-jni/gnark-test-data.go
+++ b/gnark/gnark-jni/gnark-test-data.go
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package main
 
 import (

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP196.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.gnark;
 
 import com.sun.jna.ptr.IntByReference;

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkEIP2537.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.gnark;
 
 import com.sun.jna.Library;

--- a/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkUtils.java
+++ b/gnark/src/main/java/org/hyperledger/besu/nativelib/gnark/LibGnarkUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.gnark;
 
 public class LibGnarkUtils {

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128G1AddPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128G1AddPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128G1MulPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128G1MulPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128PairingPrecompiledContractLegacyTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128PairingPrecompiledContractLegacyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 package org.hyperledger.besu.nativelib.gnark;
 

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128PairingPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/AltBN128PairingPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G1AddPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G1AddPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G1MultiExpPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G1MultiExpPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G2AddPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G2AddPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G2MultiExpPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12G2MultiExpPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12MapFp2ToG2PrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12MapFp2ToG2PrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12MapFpToG1PrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12MapFpToG1PrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12PairingPrecompiledContractTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/BLS12PairingPrecompiledContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/LibGnarkTest.java
+++ b/gnark/src/test/java/org/hyperledger/besu/nativelib/gnark/LibGnarkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/build.gradle
+++ b/ipa-multipoint/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
+++ b/ipa-multipoint/ipa_multipoint_jni/Cargo.toml
@@ -1,5 +1,5 @@
 #
-# Copyright Besu Contributors
+# Copyright contributors to Besu.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 # the License. You may obtain a copy of the License at

--- a/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/lib.rs
@@ -1,4 +1,4 @@
-/* Copyright Besu Contributors 
+/* Copyright contributors to Besu.
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *

--- a/ipa-multipoint/ipa_multipoint_jni/src/parsers.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/parsers.rs
@@ -1,3 +1,15 @@
+/* Copyright contributors to Besu.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use jni::JNIEnv;
 use jni::objects::ReleaseMode;
 use jni::sys::jbyteArray;

--- a/ipa-multipoint/ipa_multipoint_jni/src/utils.rs
+++ b/ipa-multipoint/ipa_multipoint_jni/src/utils.rs
@@ -1,3 +1,15 @@
+/* Copyright contributors to Besu.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 use banderwagon::{CanonicalDeserialize, Element, Fr};
 use verkle_trie::proof::{ExtPresent};
 use std::collections::BTreeSet;

--- a/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
+++ b/ipa-multipoint/src/main/java/org/hyperledger/besu/nativelib/ipamultipoint/LibIpaMultipoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/CommitRootTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/CommitRootTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/LibIpaMultipointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/PedersenCommitmentTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/PedersenCommitmentTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.ipa_multipoint;
 
 import org.junit.jupiter.params.ParameterizedTest;

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/proof/ExecutionWitnessData.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/proof/ExecutionWitnessData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/proof/VerifyProofTest.java
+++ b/ipa-multipoint/src/test/java/org/hyperledger/besu/nativelib/ipa_multipoint/proof/VerifyProofTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Besu Contributors
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/secp256k1/secp256k1_jni/secp256k1_ecrecover.c
+++ b/secp256k1/secp256k1_jni/secp256k1_ecrecover.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #include "secp256k1_ecrecover.h"
 #include <secp256k1.h>
 #include <secp256k1_recovery.h>

--- a/secp256k1/secp256k1_jni/secp256k1_ecrecover.h
+++ b/secp256k1/secp256k1_jni/secp256k1_ecrecover.h
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 #ifndef SECP256K1_ECRECOVER_H
 #define SECP256K1_ECRECOVER_H
 

--- a/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
+++ b/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at

--- a/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1JNI.java
+++ b/secp256k1/src/main/java/org/hyperledger/besu/nativelib/secp256k1/LibSecp256k1JNI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 package org.hyperledger.besu.nativelib.secp256k1;
 

--- a/secp256k1/src/test/java/org/hyperledger/besu/nativelib/secp256k1/Secp256K1JNIEcrecoverParameterizedTest.java
+++ b/secp256k1/src/test/java/org/hyperledger/besu/nativelib/secp256k1/Secp256K1JNIEcrecoverParameterizedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
 package org.hyperledger.besu.nativelib.secp256k1;
 

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.secp256r1;
 
 import org.hyperledger.besu.nativelib.secp256r1.besuNativeEC.BesuNativeEC;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/Signature.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/Signature.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright contributors to Besu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ */
 package org.hyperledger.besu.nativelib.secp256r1;
 
 import java.util.Arrays;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/BesuNativeEC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.secp256r1.besuNativeEC;
 
 import com.sun.jna.Library;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/KeyRecoveryResult.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/KeyRecoveryResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.secp256r1.besuNativeEC;
 
 import com.sun.jna.Structure;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/SignResult.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/SignResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.secp256r1.besuNativeEC;
 
 import com.sun.jna.Structure;

--- a/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/VerifyResult.java
+++ b/secp256r1/src/main/java/org/hyperledger/besu/nativelib/secp256r1/besuNativeEC/VerifyResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.secp256r1.besuNativeEC;
 
 import com.sun.jna.Structure;

--- a/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
+++ b/secp256r1/src/test/java/org/hyperledger/besu/nativelib/secp256r1/LibSECP256R1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright Hyperledger Besu contributors.
+ * Copyright contributors to Besu.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,8 +11,8 @@
  * specific language governing permissions and limitations under the License.
  *
  * SPDX-License-Identifier: Apache-2.0
+ *
  */
-
 package org.hyperledger.besu.nativelib.secp256r1;
 
 import org.apache.tuweni.bytes.Bytes;


### PR DESCRIPTION
Use "Copyright contributors to Besu."

Ignore licenses that have manually been changed to include original author, for example blake2f C files

This was generated using spotless and some manual edits, but not committing the spotless config in this PR as it needs more tweaks.