### PR TITLE
Release version 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 # Unreleased
+
+# 1.4.0
 * perf: add boringssl for p256Verify precompile [#275](https://github.com/hyperledger/besu-native/pull/275)
 * perf: add higher performing ecrecover-specific entrypoints for secp256k1/r1 [#277](https://github.com/hyperledger/besu-native/pull/277)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You'll need to be sure that gcc, make, autoconf, automake, and libtool are insta
 building on Ubuntu or Debian, the following command will install these dependencies for you:
 
 ```
-sudo apt-get install build-essential automake autoconf libtool patchelf
+sudo apt-get install build-essential automake autoconf libtool patchelf cmake
 ```
 
 ### OS X

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.3.2-SNAPSHOT
+version=1.4.0


### PR DESCRIPTION
* perf: add boringssl for p256Verify precompile [#275](https://github.com/hyperledger/besu-native/pull/275)
* perf: add higher performing ecrecover-specific entrypoints for secp256k1/r1 [#277](https://github.com/hyperledger/besu-native/pull/277)