### PR TITLE
Update Linux build containers from Ubuntu 22.04 to 24.04 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     if: always() && (needs.check-version.result == 'success' || needs.check-version.result == 'skipped')
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:24.04
     env:
       SKIP_GRADLE: true
     steps:
@@ -132,7 +132,7 @@ jobs:
           submodules: recursive
       - name: Build
         run: |
-          docker run -e SKIP_GRADLE=$SKIP_GRADLE -v $(pwd):/home/ubuntu ubuntu:22.04 /home/ubuntu/native-build.sh
+          docker run -e SKIP_GRADLE=$SKIP_GRADLE -v $(pwd):/home/ubuntu ubuntu:24.04 /home/ubuntu/native-build.sh
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: arithmetic-native-build-artifacts-linux-arm64


### PR DESCRIPTION
## Summary
- Update the `ubuntu:22.04` container image to `ubuntu:24.04` in both the x86-64 and arm64 Linux build jobs
- Ubuntu 24.04 is the current LTS release

## Notes for reviewers
- **glibc version bump**: Ubuntu 22.04 ships glibc 2.35, Ubuntu 24.04 ships glibc 2.39. Binaries built against the newer glibc will **not run** on systems with older glibc (e.g., Ubuntu 22.04, older RHEL/Debian). If backward compatibility with older distros is required, an alternative approach would be to keep 22.04 and remove the `apt upgrade -y` step to work around stale package metadata.
- **Package repo issue on 22.04**: The Ubuntu 22.04 Docker image has stale cached package metadata, causing 404 errors during `apt upgrade` (superseded package versions removed from mirrors).

## Test plan
- [ ] Verify `native-build-linux-x86-64` job completes successfully
- [ ] Verify `native-build-linux-arm64` job completes successfully
- [ ] Verify generated native binaries work correctly on target platforms
- [ ] Confirm minimum supported Linux platform (glibc requirement) is acceptable