### PR TITLE
Migrate build to Java 25

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           # secp256k1 dependencies
           apt-get update
           apt upgrade -y
-          DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf build-essential libtool automake wget git curl openjdk-21-jdk cmake
+          DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf build-essential libtool automake wget git curl openjdk-25-jdk cmake
           apt autoremove -y
           echo "JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))" >> $GITHUB_ENV
           # golang dependencies
@@ -266,7 +266,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25'
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
@@ -462,7 +462,7 @@ jobs:
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: adopt
-          java-version: 21
+          java-version: 25
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       - name: Execute Gradle Build

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ allprojects {
   apply plugin: 'java-library'
 
   java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_25
   }
 
   repositories {

--- a/constantine/build.gradle
+++ b/constantine/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(25)
     }
 }
 

--- a/native-build.sh
+++ b/native-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 apt-get update
-DEBIAN_FRONTEND=non-interactive apt-get install -y autoconf build-essential libtool automake curl openjdk-21-jdk git wget cmake
+DEBIAN_FRONTEND=non-interactive apt-get install -y autoconf build-essential libtool automake curl openjdk-25-jdk git wget cmake
 export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))
 export PATH=$JAVA_HOME/bin:$PATH
 wget https://go.dev/dl/go1.25.4.linux-arm64.tar.gz


### PR DESCRIPTION
Update sourceCompatibility/targetCompatibility, constantine toolchain, and all
CI/script references from Java 21 to Java 25.

Signed-off-by: Fabio Di Fabio <fabio.difabio@consensys.net>
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
